### PR TITLE
feat(pixel): enable script_version and email_id fields [WEB-5854]

### DIFF
--- a/src/pixel-v2.ts
+++ b/src/pixel-v2.ts
@@ -82,7 +82,7 @@ interface PixelPayload {
   email_hash_sha1: string;
   email_hash_md5: string;
   order_id?: string;
-  email_id?: string;
+  email_address_id?: string;
 }
 
 interface EmailHashes {
@@ -234,7 +234,7 @@ async function track(eventName: string, options: TrackOptions = {}): Promise<voi
     const { host, domain } = getHostDomain();
     const bhc = getCookie('_bhc', host, domain) || '';
     const bhp = getCookie('_bhp', host, domain) || '';
-    const [ad_network_placement_id, subscriber_id, email_id] = bhc.split('_');
+    const [ad_network_placement_id, subscriber_id, email_address_id] = bhc.split('_');
 
     const data = options.data || {};
     const {
@@ -297,7 +297,7 @@ async function track(eventName: string, options: TrackOptions = {}): Promise<voi
       email_hash_sha1,
       email_hash_md5,
       order_id,
-      email_id,
+      email_address_id,
     };
 
     // Add to batch queue
@@ -376,7 +376,9 @@ function dedupe(events: PixelPayload[]): PixelPayload[] {
       if (timeDiff < CONFIG.DEDUPE_TIME_PERIOD) {
         const debug = window?.bhpx?.debug;
         if (debug && typeof debug === 'object' && 'log' in debug) {
-          debug.log(`Event ${event_id} ${rest.event} is a duplicate since ${timeDiff} seconds ago and will be skipped.`);
+          debug.log(
+            `Event ${event_id} ${rest.event} is a duplicate since ${timeDiff} seconds ago and will be skipped.`,
+          );
         }
         return false;
       }
@@ -757,7 +759,7 @@ async function generateHash(input: string, algorithm: AlgorithmIdentifier): Prom
 }
 
 async function promiseAllObject<T extends Record<string, Promise<string>>>(
-  promisesObj: T
+  promisesObj: T,
 ): Promise<{ [K in keyof T]: string }> {
   const keys = Object.keys(promisesObj) as (keyof T)[];
   const promises = Object.values(promisesObj);
@@ -767,6 +769,6 @@ async function promiseAllObject<T extends Record<string, Promise<string>>>(
       obj[key] = results[index];
       return obj;
     },
-    {} as { [K in keyof T]: string }
+    {} as { [K in keyof T]: string },
   );
 }

--- a/src/pixel-v2.ts
+++ b/src/pixel-v2.ts
@@ -67,8 +67,7 @@ interface PixelPayload {
   event_id: string;
   url: string;
   user_agent: string;
-  // TODO: uncomment when Apiary schema is updated
-  // script_version: string;
+  script_version: string;
   content_category?: string;
   content_ids?: string[];
   content_name?: string;
@@ -83,8 +82,7 @@ interface PixelPayload {
   email_hash_sha1: string;
   email_hash_md5: string;
   order_id?: string;
-  // TODO: uncomment when Apiary schema is updated
-  // email_id?: string;
+  email_id?: string;
 }
 
 interface EmailHashes {
@@ -236,9 +234,7 @@ async function track(eventName: string, options: TrackOptions = {}): Promise<voi
     const { host, domain } = getHostDomain();
     const bhc = getCookie('_bhc', host, domain) || '';
     const bhp = getCookie('_bhp', host, domain) || '';
-    // TODO: restore email_id when Apiary schema is updated
-    // const [ad_network_placement_id, subscriber_id, email_id] = bhc.split('_');
-    const [ad_network_placement_id, subscriber_id] = bhc.split('_');
+    const [ad_network_placement_id, subscriber_id, email_id] = bhc.split('_');
 
     const data = options.data || {};
     const {
@@ -285,8 +281,7 @@ async function track(eventName: string, options: TrackOptions = {}): Promise<voi
       event_id,
       url: window.location.href,
       user_agent: window.navigator.userAgent,
-      // TODO: uncomment when Apiary schema is updated
-      // script_version: SCRIPT_VERSION,
+      script_version: SCRIPT_VERSION,
       // custom data properties are optional
       content_category,
       content_ids,
@@ -302,8 +297,7 @@ async function track(eventName: string, options: TrackOptions = {}): Promise<voi
       email_hash_sha1,
       email_hash_md5,
       order_id,
-      // TODO: uncomment when Apiary schema is updated
-      // email_id,
+      email_id,
     };
 
     // Add to batch queue


### PR DESCRIPTION
## Summary

Enables the `script_version` and `email_id` fields in the pixel payload now that the data team has updated the Apiary schema.

## Changes

- **`script_version`**: Sends the pixel version (from package.json) with every event for tracking/debugging
- **`email_id`**: Parses optional third segment from `bhcl_id` (`{placement_id}_{subscriber_id}_{email_id}`) for Ad Network email tracking

These fields were prepped in PR #7 but commented out pending schema updates. The data team has now updated the schema to accept them! 🎉

## Related

- Follows up on #7 (profile_id fix)

---
From Claudia with 💙