### PR TITLE
feat(pixel): support multiple pixel IDs per GTM container [BEE-14266]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pixel-v2",
   "private": true,
-  "version": "2.1.0",
+  "version": "2.2.0",
   "type": "module",
   "module": "./dist/pixel-v2.js",
   "scripts": {

--- a/src/pixel-v2.ts
+++ b/src/pixel-v2.ts
@@ -37,6 +37,7 @@ interface HostDomain {
 }
 
 interface TrackOptions {
+  pixelId?: string;
   data?: TrackData;
 }
 
@@ -220,8 +221,16 @@ async function track(eventName: string, options: TrackOptions = {}): Promise<voi
       return;
     }
 
-    if (!_pixelId) {
+    // Use pixelId from options if provided, otherwise fall back to initialized _pixelId
+    const pixelId = options.pixelId || _pixelId;
+
+    if (!pixelId) {
       throw new Error('Pixel ID not initialized');
+    }
+
+    // Validate pixelId if provided in options
+    if (options.pixelId) {
+      validatePixelId(options.pixelId);
     }
     if (!eventName || typeof eventName !== 'string') {
       throw new Error('Invalid event name');
@@ -270,7 +279,7 @@ async function track(eventName: string, options: TrackOptions = {}): Promise<voi
     const { email_hash_sha256, email_hash_sha1, email_hash_md5 } = await hashEmail(email);
 
     const payload: PixelPayload = {
-      pixel_id: _pixelId,
+      pixel_id: pixelId,
       ad_network_placement_id: ad_network_placement_id || '',
       subscriber_id: subscriber_id || '',
       profile_id: bhp, // anonymous profile id

--- a/template.tpl
+++ b/template.tpl
@@ -271,7 +271,7 @@ const injectScript = require('injectScript');
 const callInWindow = require('callInWindow');
 const copyFromWindow = require('copyFromWindow');
 
-const VERSION = 'v2.0.1';
+const VERSION = 'v2.2.0';
 
 log('beehiiv pixel loaded', VERSION);
 // Constants
@@ -299,6 +299,7 @@ const pixel_id = eventData.pixel_id;
 
 // Prepare the event data payload
 const payload = {
+  pixelId: pixel_id,
   data: {
     currency: eventData.currency,
     value_cents: eventData.value_cents ? makeInteger(eventData.value_cents) : undefined,


### PR DESCRIPTION
## Summary

Morning Brew uses a single GTM container to host multiple beehiiv pixels for different publications. They use firing trigger filters to send tracking events based on hostname. However, the beehiiv pixel currently stores a single `_pixelId` during `init()`, which means when all 4 pixels initialize, only the last one's ID gets stored — and ALL subsequent tracking events get attributed to that single pixel. 🤦‍♀️

## The Fix 🔧

Add an optional `pixelId` parameter to the `track()` function options:

```typescript
interface TrackOptions {
  pixelId?: string;  // NEW - optional override
  data?: TrackData;
}

async function track(eventName: string, options: TrackOptions = {}): Promise<void> {
  const pixelId = options.pixelId || _pixelId;  // Use passed pixelId or fall back
  // ...
}
```

The GTM template now includes `pixelId` in every track payload, so each publication's pixel correctly attributes events to itself.

## Changes

- **pixel-v2.ts**: Add `pixelId` to `TrackOptions`, use it in `track()`, validate when provided
- **template.tpl**: Include `pixelId: pixel_id` in payload for all track calls
- **package.json**: Bump version to 2.2.0

## Backward Compatibility ✅

Fully backward compatible! If no `pixelId` is passed, falls back to the initialized `_pixelId` (current behavior).

## Test Plan

- [x] Build succeeds (`npm run build`)
- [x] Verify with GTM preview mode that each pixel sends its own ID
- [x] Test with multiple pixels in same container
- [x] Verify fallback works when `pixelId` not provided

---
From Claudia with 💙