### PR TITLE
fix(pixel): silence console.log in production builds [BEE-15342]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pixel-v2",
   "private": true,
-  "version": "2.2.0",
+  "version": "2.2.1",
   "type": "module",
   "module": "./dist/pixel-v2.js",
   "scripts": {

--- a/src/pixel-v2.ts
+++ b/src/pixel-v2.ts
@@ -478,7 +478,7 @@ function handleClickIdentification(): void {
   }
 }
 
-console.log(`beehiiv pixel v${SCRIPT_VERSION} loaded`);
+debugLog(`beehiiv pixel v${SCRIPT_VERSION} loaded`);
 
 // Enhanced initialization with validation and cleanup
 function init(pixelId: string, options: InitOptions = {}): void {
@@ -486,7 +486,7 @@ function init(pixelId: string, options: InitOptions = {}): void {
     validatePixelId(pixelId);
     _pixelId = pixelId;
 
-    console.log(`beehiiv pixel v${SCRIPT_VERSION} initialized`);
+    debugLog(`beehiiv pixel v${SCRIPT_VERSION} initialized`);
 
     const { host, domain } = getHostDomain();
 
@@ -767,7 +767,7 @@ function updateBHCCookie(name: string, value: string, host: string, domain: stri
     name = `${name}_${host}`;
   }
   updateCookie(name, value, domain);
-  console.log(`bhcl_id added to cookie: ${name}`);
+  debugLog(`bhcl_id added to cookie: ${name}`);
 }
 
 function updateCookie(name: string, value: string, domain: string): void {


### PR DESCRIPTION
## Summary

A client (Attio) flagged that our pixel is writing `console.log` output on their production site. Three calls were firing unconditionally — regardless of debug mode.

## The Investigation 🔍

Grep'd for `console.log` across `pixel-v2.ts` and found three ungated calls mixed in with the properly gated `debugLog()` ones:

| Line | Output | Impact |
|------|--------|--------|
| 481 | `beehiiv pixel v2.x.x loaded` | Every page load |
| 489 | `beehiiv pixel v2.x.x initialized` | Every init call |
| 770 | `bhcl_id added to cookie: _bhc` | Every click track |

The rest of the logging already goes through `debugLog()`, which is gated behind `CONFIG.DEBUG` (off by default, enabled via `init({ debug: true })`). These three just slipped through.

## The Fix 🔧

Replaced all three `console.log()` calls with `debugLog()`. Zero behavior change when debug mode is on — total silence when it's off.

## The Result ✨

Clean console for every advertiser running our pixel in production. Debug output is still fully available when needed via the `debug: true` init option.

---
From Claudia with 💙