### PR TITLE
feat(pixel): Shopify-native two-halves architecture + defensive payload validation [BEE-19449]

### DIFF
--- a/SHOPIFY.md
+++ b/SHOPIFY.md
@@ -1,0 +1,106 @@
+# beehiiv Pixel V2 — Shopify Integration
+
+## Overview
+
+Shopify integration uses **two coordinated halves** that share storefront cookies for attribution:
+
+1. **`pixel-v2.js` in `theme.liquid`** — runs in the real storefront context. Captures `?bhcl_id=...` on landing, writes the `_bhc` / `_bhp` cookies to the storefront cookie jar, and tracks non-checkout events (pageviews, signups, custom events).
+2. **`pixel-shopify.js` as a Shopify Custom Pixel** — runs in Shopify's checkout sandbox. Reads `_bhc` / `_bhp` via Shopify's `browser.cookie` API and fires the `purchase` event with full attribution on `checkout_completed`.
+
+> **Why two halves?** Shopify's Custom Pixel sandbox is an isolated iframe — it can't read or write the storefront's cookie jar synchronously, and `window.location` reflects the sandbox URL rather than the storefront URL. So click capture (`bhcl_id` → `_bhc` cookie) has to happen on the storefront itself, in `theme.liquid`. The Custom Pixel then reads what `theme.liquid` wrote, and fires the conversion event with the attribution intact.
+
+## Part 1 — Install `pixel-v2.js` in `theme.liquid`
+
+This half captures the click and handles non-checkout events on the storefront.
+
+1. From the Shopify Admin, go to **Online Store → Themes → Edit code**
+2. Open `layout/theme.liquid`
+3. Paste the following snippet just before the closing `</head>` tag. Replace `PIXEL_ID` with the value from your beehiiv Advertiser Portal:
+
+```html
+<!-- beehiiv Pixel V2 — storefront -->
+<script>
+(function(){try{
+  !function (f, b, e, h, i, v) {
+    if (f.bhpx) return;
+    i = f.bhpx = function () {
+      i.callMethod ?
+        i.callMethod.apply(i, arguments) : i.queue.push(arguments);
+    };
+    if (!f._bhpx) f._bhpx = i;
+    i.push = i; i.loaded = !0; i.version = '1.0';
+    i.queue = [];
+    v = b.createElement(e); v.async = !0;
+    v.type = 'module';
+    v.src = 'https://beehiiv-adnetwork-production.s3.amazonaws.com/pixel-v2.js';
+    h = b.getElementsByTagName(e)[0];
+    h.parentNode.insertBefore(v, h);
+  }(window, document, 'script');
+
+  bhpx('init', 'PIXEL_ID', { trackClientNavigation: true });
+}catch{/*swallow*/}})();
+</script>
+```
+
+4. Save the theme.
+
+**What this does:**
+- On any storefront page load, parses `?bhcl_id=...` from the URL if present, validates it, and writes `_bhc` to the storefront cookie jar.
+- Generates a `_bhp` profile cookie on first visit so anonymous activity can be stitched together later.
+- Fires a `pageview` event on every navigation.
+
+You can also fire custom events from the storefront (e.g., signup completion, add-to-cart) by calling `bhpx('track', 'lead', { ... })`. See the main [README](./README.md) for the supported event list.
+
+## Part 2 — Install `pixel-shopify.js` as a Custom Pixel
+
+This half handles checkout `purchase` attribution.
+
+1. From the Shopify Admin, go to **Settings → Customer events**
+2. Click **Add custom pixel** and name it `beehiiv Pixel V2 conversion`
+3. Copy the entire contents of [`dist/pixel-shopify.js`](./dist/pixel-shopify.js) into the **Code** field
+4. Find the line `const PIXEL_ID = 'PIXEL_ID';` near the top and replace `PIXEL_ID` with your beehiiv pixel ID
+5. Set **Permission** to `Not required` (the pixel only reads cookies it sets itself; no PII is collected without the standard checkout email field)
+6. Set **Data sale** to whatever your store policy requires
+7. Click **Save**, then **Connect**
+
+**What this does:**
+- Subscribes to Shopify's `page_viewed` event to ensure `_bhp` exists and to capture any `bhcl_id` query param that arrives in checkout (e.g., direct-to-checkout deep links)
+- Subscribes to `checkout_completed` and fires a `purchase` event with `order_id`, hashed `email`, `currency`, and `value_cents`
+- Reads the `_bhc` / `_bhp` cookies written by Part 1 via Shopify's `browser.cookie` API, so attribution flows through to the conversion event
+
+## Testing
+
+1. In the Custom Pixel UI, click **Preview** and complete a test checkout
+2. Open your browser's Network tab and filter for `ingestion.apiary.beehiiv.net`
+3. Verify a POST is sent with the expected payload — in particular that `ad_network_placement_id`, `subscriber_id`, and `email_address_id` are populated when you arrived from a beehiiv ad link
+
+If those attribution fields are empty:
+- Confirm Part 1 is installed in `theme.liquid` and the storefront has been visited recently from a beehiiv ad URL (containing `?bhcl_id=...`)
+- Check that the `_bhc` cookie exists on the storefront domain in your browser's DevTools
+- Confirm the Custom Pixel's `Permission` setting isn't blocking cookie reads
+
+## Why the Old "Custom-Pixel-Only" Approach Doesn't Work
+
+Earlier versions of this guide instructed advertisers to load `pixel-v2.js` *inside* the Custom Pixel sandbox. That pattern fires the `purchase` event but **silently fails on attribution** — `pixel-v2.js`'s synchronous cookie reads target the sandbox iframe's cookie jar, not the storefront's, so `_bhc` and `_bhp` are always empty. The event reaches our endpoint but can't be linked to the originating ad click.
+
+The two-halves architecture above is the only reliable path because click capture must happen in the storefront context (where `document.cookie` and `window.location` reflect the real page) and conversion firing must happen in the sandbox (which is the only context with access to Shopify's checkout event stream).
+
+## Field Reference
+
+Both halves send the same `PixelPayload` shape to `https://ingestion.apiary.beehiiv.net/api/v2/ingestion/pixel`. The fields most relevant to Shopify advertisers:
+
+| Field | Source | Notes |
+|---|---|---|
+| `pixel_id` | Hardcoded in snippet | Your beehiiv pixel ID |
+| `event` | `'pageview'` / `'purchase'` / etc. | Lowercase |
+| `event_id` | Generated UUID | Used for deduplication |
+| `url` | Storefront URL | From `window.location` or `event.context.document.location.href` |
+| `ad_network_placement_id` | `_bhc` cookie | Empty if user didn't arrive from a beehiiv ad |
+| `subscriber_id` | `_bhc` cookie | Same |
+| `email_address_id` | `_bhc` cookie | Same |
+| `profile_id` | `_bhp` cookie | Anonymous user identifier |
+| `order_id` | `event.data.checkout.order.id` | Purchase only |
+| `value_cents` | `event.data.checkout.totalPrice.amount * 100` | Purchase only |
+| `currency` | `event.data.checkout.currencyCode` | Purchase only |
+| `email_hash_sha256` | SHA-256 of checkout email | Purchase only |
+| `email_hash_sha1` | SHA-1 of checkout email | Purchase only |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pixel-v2",
   "private": true,
-  "version": "2.2.1",
+  "version": "2.2.2",
   "type": "module",
   "module": "./dist/pixel-v2.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -13,9 +13,6 @@
     "run-advertiser:web": "serve ./test -l 9999",
     "run-advertiser:caddy": "caddy run --config ./test/Caddyfile"
   },
-  "dependencies": {
-    "js-md5": "^0.8.3"
-  },
   "devDependencies": {
     "@types/node": "^25.0.3",
     "chokidar-cli": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pixel-v2",
   "private": true,
-  "version": "2.2.2",
+  "version": "2.2.3",
   "type": "module",
   "module": "./dist/pixel-v2.js",
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      js-md5:
-        specifier: ^0.8.3
-        version: 0.8.3
     devDependencies:
       '@types/node':
         specifier: ^25.0.3
@@ -1243,9 +1239,6 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-
-  js-md5@0.8.3:
-    resolution: {integrity: sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==}
 
   json-parse-better-errors@1.0.2:
     resolution: {integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==}
@@ -3528,8 +3521,6 @@ snapshots:
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
-
-  js-md5@0.8.3: {}
 
   json-parse-better-errors@1.0.2: {}
 

--- a/scripts/build_pixeljs
+++ b/scripts/build_pixeljs
@@ -5,7 +5,14 @@ copy=$2
 if [[ "$ENV" == "" ]]; then
   ENV=dev
 fi
+
+# pixel-v2 is the CDN-hosted script for direct injection / GTM / theme.liquid.
+# pixel-shopify is the paste-in snippet for Shopify Customer Events sandbox —
+# advertisers paste dist/pixel-shopify.js content directly into the Shopify UI,
+# so it is NOT uploaded to S3.
 doppler run --project swarm --config "$ENV" --command "VITE_BUILD_ENTRY=pixel-v2 pnpm vite build"
+doppler run --project swarm --config "$ENV" --command "VITE_BUILD_ENTRY=pixel-shopify pnpm vite build"
+
 if [[ "$copy" == "--copy" ]]; then
   doppler run --project swarm --config "$ENV" -- scripts/upload_to_s3 dist/pixel-v2.js
 fi

--- a/src/lib/cookies.ts
+++ b/src/lib/cookies.ts
@@ -1,0 +1,103 @@
+import type { HostDomain } from './types';
+import { isValidClickId } from './utils';
+
+// Domains where multiple beehiiv publications share a hostname suffix
+// (e.g. pub1.beehiiv.com / pub2.beehiiv.com). On these we host-scope the
+// cookie name to prevent cross-publication collision. External advertiser
+// sites (Shopify stores, GTM installs, etc.) don't have this problem.
+export const EXCLUDED_DOMAINS = ['beehiiv.com', 'staginghiiv.com', 'localhiiv.com'];
+
+const COOKIE_MAX_AGE_SECONDS = 365 * 24 * 60 * 60;
+
+export interface CookieJar {
+  get(name: CookieName): Promise<string>;
+  set(name: CookieName, value: string): Promise<void>;
+}
+
+export type CookieName = '_bhc' | '_bhp';
+
+export function getHostDomain(hostname: string): HostDomain {
+  if (hostname === 'localhost' || hostname === '127.0.0.1') {
+    return { host: '', domain: 'localhost' };
+  }
+  let host = 'www';
+  let domain = '';
+  const parts = hostname.split('.');
+  if (parts.length < 3) {
+    domain = `${parts[0]}.${parts[1]}`;
+  } else {
+    host = parts[0];
+    domain = `${parts[1]}.${parts[2]}`;
+  }
+  return { host, domain };
+}
+
+// Returns the bhcl_id from a URL's query string, or null if absent/malformed.
+export function parseClickId(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    const bhclId = parsed.searchParams.get('bhcl_id');
+    if (!bhclId) return null;
+    if (!isValidClickId(bhclId)) {
+      console.error('Invalid bhcl_id format');
+      return null;
+    }
+    return bhclId;
+  } catch {
+    return null;
+  }
+}
+
+// Sync cookie jar backed by document.cookie. Wraps reads/writes in Promises so
+// callers can treat it identically to async jars (e.g. Shopify's browser.cookie).
+//
+// Naming rules (preserved from the original implementation):
+//  - On EXCLUDED_DOMAINS, _bhc writes use `_bhc_<host>` to avoid collision
+//    between sibling beehiiv publications. _bhp writes are always plain.
+//  - Reads fall back through plain → _<host> → _www until they find a match.
+export class DocumentCookieJar implements CookieJar {
+  private isSecure = true;
+
+  constructor(
+    private host: string,
+    private domain: string,
+  ) {}
+
+  async get(name: CookieName): Promise<string> {
+    const [cookie] = this.findCookieWithHost(name);
+    return cookie ? cookie.split('=')[1] : '';
+  }
+
+  async set(name: CookieName, value: string): Promise<void> {
+    const isExcludedDomain = EXCLUDED_DOMAINS.includes(this.domain);
+    // _bhc on beehiiv-owned domains is host-scoped; _bhp and everything else stays plain
+    const effectiveName = isExcludedDomain && name === '_bhc' ? `${name}_${this.host}` : name;
+    const props = `domain=.${this.domain}; path=/; samesite=strict; ${this.isSecure ? 'secure;' : ''} max-age=${COOKIE_MAX_AGE_SECONDS}`;
+    document.cookie = `${effectiveName}=${value}; ${props}`;
+  }
+
+  private findCookieWithHost(name: string): [string | undefined, string] {
+    const allCookies = document.cookie.split(';');
+    let cookie: string | undefined;
+    const isExcludedDomain = EXCLUDED_DOMAINS.includes(this.domain);
+
+    if (!isExcludedDomain) {
+      cookie = this.findCookie(allCookies, name);
+    }
+    if (!cookie) {
+      const hostScoped = `${name}_${this.host}`;
+      cookie = this.findCookie(allCookies, hostScoped);
+      if (cookie) return [cookie, hostScoped];
+    }
+    if (!cookie && this.host !== 'www') {
+      const wwwScoped = `${name}_www`;
+      cookie = this.findCookie(allCookies, wwwScoped);
+      if (cookie) return [cookie, wwwScoped];
+    }
+    return [cookie, name];
+  }
+
+  private findCookie(allCookies: string[], name: string): string | undefined {
+    return allCookies.find((cookie) => cookie.trim().startsWith(`${name}=`));
+  }
+}

--- a/src/lib/dedupe.ts
+++ b/src/lib/dedupe.ts
@@ -1,0 +1,80 @@
+import type { PixelPayload } from './types';
+
+const STORAGE_KEY = 'bhpx_processed_events';
+const DEDUPE_TIME_PERIOD_SECONDS = 15 * 60;
+
+interface ProcessedEvents {
+  [hash: string]: number;
+}
+
+// Sync 32-bit djb2 hash — collision rate is negligible for the small number
+// of events any single user fires within a 15-minute window. Replaces the
+// previous MD5-based dedupe so we can drop the js-md5 dependency entirely.
+function hashString(str: string): string {
+  let hash = 5381;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) + hash + str.charCodeAt(i)) | 0;
+  }
+  return (hash >>> 0).toString(36);
+}
+
+// Filters a batch to remove events that match a previously-seen event (within
+// the 15-min window) or that duplicate another event in the current batch.
+// Stable: preserves the order of non-duplicate events.
+export function dedupe(events: PixelPayload[]): PixelPayload[] {
+  const currentTime = Math.floor(Date.now() / 1000);
+
+  let processedEvents: ProcessedEvents = {};
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) processedEvents = JSON.parse(stored) as ProcessedEvents;
+  } catch (error) {
+    console.warn('Failed to load processed events from localStorage:', error);
+  }
+
+  const seen = new Set<string>();
+  const filtered = events.filter((event) => {
+    const eventHash = hashEventForDedupe(event);
+
+    if (seen.has(eventHash)) return false;
+
+    if (processedEvents[eventHash]) {
+      const age = currentTime - processedEvents[eventHash];
+      if (age < DEDUPE_TIME_PERIOD_SECONDS) return false;
+    }
+
+    seen.add(eventHash);
+    return true;
+  });
+
+  const updated: ProcessedEvents = { ...processedEvents };
+  filtered.forEach((event) => {
+    updated[hashEventForDedupe(event)] = currentTime;
+  });
+
+  // Garbage-collect expired entries so localStorage doesn't grow unbounded.
+  Object.keys(updated).forEach((hash) => {
+    if (updated[hash] < currentTime - DEDUPE_TIME_PERIOD_SECONDS) {
+      delete updated[hash];
+    }
+  });
+
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+  } catch (error) {
+    console.warn('Failed to save processed events to localStorage:', error);
+  }
+
+  return filtered;
+}
+
+// Excludes timestamps and event_id from the hash so a "same event, different
+// instant" still dedupes. Without this, every pageview would be unique.
+function hashEventForDedupe(event: PixelPayload): string {
+  const { timestamp, landed_timestamp, sent_timestamp, event_id, ...rest } = event;
+  void timestamp;
+  void landed_timestamp;
+  void sent_timestamp;
+  void event_id;
+  return hashString(JSON.stringify(rest));
+}

--- a/src/lib/email-hash.ts
+++ b/src/lib/email-hash.ts
@@ -1,0 +1,19 @@
+import type { EmailHashes } from './types';
+
+export async function hashEmail(email: string): Promise<EmailHashes> {
+  if (!email) {
+    return { email_hash_sha256: '', email_hash_sha1: '' };
+  }
+  const [email_hash_sha256, email_hash_sha1] = await Promise.all([
+    generateHash(email, 'SHA-256'),
+    generateHash(email, 'SHA-1'),
+  ]);
+  return { email_hash_sha256, email_hash_sha1 };
+}
+
+async function generateHash(input: string, algorithm: AlgorithmIdentifier): Promise<string> {
+  const msgBuffer = new TextEncoder().encode(input);
+  const hashBuffer = await crypto.subtle.digest(algorithm, msgBuffer);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map((byte) => byte.toString(16).padStart(2, '0')).join('');
+}

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -1,0 +1,23 @@
+// Single source of truth for the event names the beehiiv pixel accepts.
+// Both pixel-v2 and pixel-shopify gate track() on this list — events with any
+// other name are dropped client-side with a console warning. Keep this in sync
+// with the README's "Supported Events" table.
+
+export const SUPPORTED_EVENTS = [
+  'pageview',
+  'conversion',
+  'lead',
+  'complete_registration',
+  'purchase',
+  'initiate_checkout',
+  'start_trial',
+  'subscribe',
+] as const;
+
+export type SupportedEvent = (typeof SUPPORTED_EVENTS)[number];
+
+const SUPPORTED_SET = new Set<string>(SUPPORTED_EVENTS);
+
+export function isSupportedEvent(name: string): name is SupportedEvent {
+  return SUPPORTED_SET.has(name);
+}

--- a/src/lib/payload.ts
+++ b/src/lib/payload.ts
@@ -1,7 +1,7 @@
 import type { CookieJar } from './cookies';
 import { hashEmail } from './email-hash';
 import type { PixelPayload, TrackData } from './types';
-import { generateUUID, getInt } from './utils';
+import { generateUUID, getInt, isValidUUID } from './utils';
 
 export interface BuildPayloadContext {
   pixelId: string;
@@ -21,7 +21,14 @@ export async function buildPayload(ctx: BuildPayloadContext): Promise<PixelPaylo
   const timestamp = Date.now();
 
   const [bhc, bhp] = await Promise.all([ctx.cookies.get('_bhc'), ctx.cookies.get('_bhp')]);
-  const [ad_network_placement_id, subscriber_id, email_address_id] = bhc.split('_');
+  // _bhc is `<placement>_<subscriber>_<email_address>`. If a click URL ships
+  // with unsubstituted template placeholders (e.g. `?bhcl_id={UUID}_{SUBSCRIBER}_{ID}`),
+  // we end up with literal "SUBSCRIBER"/"ID" strings here. Drop anything that
+  // isn't a real UUID so the backend's UUID validator doesn't reject the event.
+  const [rawPlacement, rawSubscriber, rawEmail] = bhc.split('_');
+  const ad_network_placement_id = isValidUUID(rawPlacement) ? rawPlacement : '';
+  const subscriber_id = isValidUUID(rawSubscriber) ? rawSubscriber : '';
+  const email_address_id = isValidUUID(rawEmail) ? rawEmail : undefined;
 
   // Email comes either from explicit data, or as a URL query param fallback
   // (advertisers sometimes pass email in the conversion URL).
@@ -39,8 +46,8 @@ export async function buildPayload(ctx: BuildPayloadContext): Promise<PixelPaylo
 
   return {
     pixel_id: ctx.pixelId,
-    ad_network_placement_id: ad_network_placement_id || '',
-    subscriber_id: subscriber_id || '',
+    ad_network_placement_id,
+    subscriber_id,
     profile_id: bhp,
     event: ctx.eventName,
     timestamp,

--- a/src/lib/payload.ts
+++ b/src/lib/payload.ts
@@ -1,0 +1,68 @@
+import type { CookieJar } from './cookies';
+import { hashEmail } from './email-hash';
+import type { PixelPayload, TrackData } from './types';
+import { generateUUID, getInt } from './utils';
+
+export interface BuildPayloadContext {
+  pixelId: string;
+  eventName: string;
+  url: string;
+  userAgent: string;
+  scriptVersion: string;
+  cookies: CookieJar;
+  data: TrackData;
+}
+
+// Builds the canonical pixel payload from an event context. Both pixel-v2
+// (direct injection) and pixel-shopify (sandbox) funnel through this so the
+// payload schema can't drift between environments.
+export async function buildPayload(ctx: BuildPayloadContext): Promise<PixelPayload> {
+  const event_id = generateUUID();
+  const timestamp = Date.now();
+
+  const [bhc, bhp] = await Promise.all([ctx.cookies.get('_bhc'), ctx.cookies.get('_bhp')]);
+  const [ad_network_placement_id, subscriber_id, email_address_id] = bhc.split('_');
+
+  // Email comes either from explicit data, or as a URL query param fallback
+  // (advertisers sometimes pass email in the conversion URL).
+  let email = ctx.data.email || '';
+  if (!email) {
+    try {
+      const url = new URL(ctx.url);
+      email = url.searchParams.get('email') || '';
+    } catch {
+      // ignore — URL parsing failure means no email fallback
+    }
+  }
+
+  const { email_hash_sha256, email_hash_sha1 } = await hashEmail(email);
+
+  return {
+    pixel_id: ctx.pixelId,
+    ad_network_placement_id: ad_network_placement_id || '',
+    subscriber_id: subscriber_id || '',
+    profile_id: bhp,
+    event: ctx.eventName,
+    timestamp,
+    landed_timestamp: timestamp,
+    sent_timestamp: timestamp,
+    event_id,
+    url: ctx.url,
+    user_agent: ctx.userAgent,
+    script_version: ctx.scriptVersion,
+    content_category: ctx.data.content_category,
+    content_ids: ctx.data.content_ids,
+    content_name: ctx.data.content_name,
+    content_type: ctx.data.content_type,
+    currency: ctx.data.currency,
+    num_items: ctx.data.num_items,
+    predicted_ltv_cents: getInt(ctx.data.predicted_ltv_cents),
+    search_string: ctx.data.search_string,
+    status: ctx.data.status,
+    value_cents: getInt(ctx.data.value_cents),
+    email_hash_sha256,
+    email_hash_sha1,
+    order_id: ctx.data.order_id,
+    email_address_id,
+  };
+}

--- a/src/lib/transport.ts
+++ b/src/lib/transport.ts
@@ -1,0 +1,54 @@
+import type { PixelPayload } from './types';
+
+const APIARY_ENDPOINT = import.meta.env.VITE_PIXEL_V2_APIARY_ENDPOINT as string;
+
+export interface TransportConfig {
+  retryAttempts: number;
+  retryDelay: number;
+}
+
+const DEFAULT_CONFIG: TransportConfig = {
+  retryAttempts: 3,
+  retryDelay: 1000,
+};
+
+// Sends a batch of payloads to apiary. Tries sendBeacon first (best-effort,
+// fire-and-forget, survives page unload), falls back to fetch with retry if
+// sendBeacon is unavailable or rejects the payload (typically over 64KB).
+export async function sendToApiary(
+  payloads: PixelPayload[],
+  config: Partial<TransportConfig> = {},
+): Promise<void> {
+  if (payloads.length === 0) return;
+  const cfg = { ...DEFAULT_CONFIG, ...config };
+  const body = JSON.stringify(payloads);
+
+  if (typeof navigator !== 'undefined' && navigator.sendBeacon) {
+    const sent = navigator.sendBeacon(APIARY_ENDPOINT, body);
+    if (sent) return;
+    // sendBeacon returns false when the user agent refuses to queue the
+    // transfer (e.g. payload too large). Fall through to fetch retry.
+  }
+
+  await sendWithRetry(body, cfg, 0);
+}
+
+async function sendWithRetry(body: string, cfg: TransportConfig, attempt: number): Promise<void> {
+  try {
+    const response = await fetch(APIARY_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+      keepalive: true,
+    });
+    if (!response.ok && response.status >= 500 && attempt < cfg.retryAttempts) {
+      throw new Error(`apiary returned ${response.status}`);
+    }
+  } catch (err) {
+    if (attempt < cfg.retryAttempts) {
+      await new Promise((resolve) => setTimeout(resolve, cfg.retryDelay * (attempt + 1)));
+      return sendWithRetry(body, cfg, attempt + 1);
+    }
+    throw err;
+  }
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,71 @@
+// Single source of truth for the pixel payload contract.
+// Changing a field here forces both pixel-v2 and pixel-shopify to update.
+
+export interface TrackData {
+  content_category?: string;
+  content_ids?: string[];
+  content_name?: string;
+  content_type?: string;
+  currency?: string;
+  num_items?: number;
+  predicted_ltv_cents?: number | string;
+  search_string?: string;
+  status?: string;
+  value_cents?: number | string;
+  order_id?: string;
+  email?: string;
+}
+
+export interface TrackOptions {
+  pixelId?: string;
+  data?: TrackData;
+}
+
+export interface EmailHashes {
+  email_hash_sha256: string;
+  email_hash_sha1: string;
+}
+
+export interface HostDomain {
+  host: string;
+  domain: string;
+}
+
+export interface PixelPayload {
+  pixel_id: string;
+  ad_network_placement_id: string;
+  subscriber_id: string;
+  profile_id: string;
+  event: string;
+  timestamp: number;
+  landed_timestamp: number;
+  sent_timestamp: number;
+  event_id: string;
+  url: string;
+  user_agent: string;
+  script_version: string;
+  content_category?: string;
+  content_ids?: string[];
+  content_name?: string;
+  content_type?: string;
+  currency?: string;
+  num_items?: number;
+  predicted_ltv_cents?: number;
+  search_string?: string;
+  status?: string;
+  value_cents?: number;
+  email_hash_sha256: string;
+  email_hash_sha1: string;
+  order_id?: string;
+  email_address_id?: string;
+}
+
+export interface InitOptions {
+  autoConfig?: boolean;
+  debug?: boolean;
+  disableDedupe?: boolean;
+  trackClientNavigation?: boolean;
+  batchSize?: number;
+  batchInterval?: number;
+  retryAttempts?: number;
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,37 @@
+export function generateUUID(): string {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+export function isCrawler(): boolean {
+  const ua = navigator.userAgent.toLowerCase();
+  const crawlerRegex =
+    /(bot|crawl|spider|slurp|archiver|indexer|facebookexternalhit|twitterbot|bingpreview|applebot|siteaudit|semrush|ahrefs|mj12bot|seznambot|screaming frog|dotbot)/i;
+  return crawlerRegex.test(ua);
+}
+
+export function getInt(s: number | string | undefined): number | undefined {
+  if (typeof s === 'number') return s;
+  if (typeof s === 'string') return Number.parseInt(s, 10);
+  return undefined;
+}
+
+export function validatePixelId(pixelId: string): boolean {
+  if (!pixelId || typeof pixelId !== 'string') {
+    throw new Error('Invalid pixel ID');
+  }
+  const pixelIdRegex = /^[a-zA-Z0-9-_]{8,}$/;
+  if (!pixelIdRegex.test(pixelId)) {
+    throw new Error('Invalid pixel ID format');
+  }
+  return true;
+}
+
+// Validates a beehiiv click id (bhcl_id) format. Used both for query-param
+// parsing on landing and for sanity-checking cookie reads.
+export function isValidClickId(bhclId: string): boolean {
+  return /^[a-zA-Z0-9-_]{8,}$/.test(bhclId);
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -13,10 +13,21 @@ export function isCrawler(): boolean {
   return crawlerRegex.test(ua);
 }
 
+// Coerces to an integer. Numbers are rounded — `32.63 * 100 = 3263.0000000000005`
+// would otherwise sail through and trip the backend's decimal validator.
 export function getInt(s: number | string | undefined): number | undefined {
-  if (typeof s === 'number') return s;
-  if (typeof s === 'string') return Number.parseInt(s, 10);
+  if (typeof s === 'number') return Number.isFinite(s) ? Math.round(s) : undefined;
+  if (typeof s === 'string') {
+    const n = Number.parseInt(s, 10);
+    return Number.isNaN(n) ? undefined : n;
+  }
   return undefined;
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isValidUUID(s: string | undefined): boolean {
+  return !!s && UUID_RE.test(s);
 }
 
 export function validatePixelId(pixelId: string): boolean {

--- a/src/pixel-shopify.ts
+++ b/src/pixel-shopify.ts
@@ -1,10 +1,17 @@
 import { version as SCRIPT_VERSION } from '../package.json';
 import type { CookieJar, CookieName } from './lib/cookies';
 import { parseClickId } from './lib/cookies';
+import { SUPPORTED_EVENTS, isSupportedEvent } from './lib/events';
 import { buildPayload } from './lib/payload';
 import { sendToApiary } from './lib/transport';
 import type { TrackData } from './lib/types';
 import { generateUUID } from './lib/utils';
+
+// Injected at the top of the IIFE by vite.config.ts `rollupOptions.output.intro`.
+// We declare it here so TypeScript knows it exists in scope; the real `const`
+// declaration only appears in the built bundle, near the `version` constant
+// where it's easy for advertisers to find and edit.
+declare const pixelId: string;
 
 // Shopify Custom Pixel sandbox globals. These don't exist anywhere else, so
 // declaring them ambient keeps the rest of the file plain TypeScript.
@@ -35,10 +42,6 @@ interface ShopifyEvent {
     };
   };
 }
-
-// IMPORTANT: Replace PIXEL_ID with the value from your beehiiv Advertiser Portal
-// before pasting this snippet into Shopify's Customer Events / Custom Pixel UI.
-const PIXEL_ID = 'PIXEL_ID';
 
 // Adapter for Shopify's async browser.cookie API. Naming is plain (_bhc / _bhp)
 // because Shopify storefronts aren't on beehiiv-owned domains, so the
@@ -72,12 +75,20 @@ async function captureClickIdFromUrl(url: string | undefined): Promise<void> {
 
 async function track(eventName: string, event: ShopifyEvent, data: TrackData): Promise<void> {
   try {
+    const normalized = eventName.toLowerCase();
+    if (!isSupportedEvent(normalized)) {
+      console.warn(
+        `[bhpx-shopify] unsupported event "${eventName}" — must be one of: ${SUPPORTED_EVENTS.join(', ')}`,
+      );
+      return;
+    }
+
     const url = event.context?.document?.location?.href || '';
     const userAgent = event.context?.navigator?.userAgent || '';
 
     const payload = await buildPayload({
-      pixelId: PIXEL_ID,
-      eventName: eventName.toLowerCase(),
+      pixelId,
+      eventName: normalized,
       url,
       userAgent,
       scriptVersion: SCRIPT_VERSION,

--- a/src/pixel-shopify.ts
+++ b/src/pixel-shopify.ts
@@ -1,0 +1,114 @@
+import { version as SCRIPT_VERSION } from '../package.json';
+import type { CookieJar, CookieName } from './lib/cookies';
+import { parseClickId } from './lib/cookies';
+import { buildPayload } from './lib/payload';
+import { sendToApiary } from './lib/transport';
+import type { TrackData } from './lib/types';
+import { generateUUID } from './lib/utils';
+
+// Shopify Custom Pixel sandbox globals. These don't exist anywhere else, so
+// declaring them ambient keeps the rest of the file plain TypeScript.
+declare const analytics: {
+  subscribe(eventName: string, callback: (event: ShopifyEvent) => void): void;
+};
+declare const browser: {
+  cookie: {
+    get(name: string): Promise<string | null>;
+    set(name: string, value: string): Promise<void>;
+  };
+};
+
+interface ShopifyEvent {
+  id?: string;
+  name?: string;
+  timestamp?: string;
+  context?: {
+    document?: { location?: { href?: string } };
+    navigator?: { userAgent?: string };
+  };
+  data?: {
+    checkout?: {
+      email?: string;
+      order?: { id?: string };
+      currencyCode?: string;
+      totalPrice?: { amount?: number };
+    };
+  };
+}
+
+// IMPORTANT: Replace PIXEL_ID with the value from your beehiiv Advertiser Portal
+// before pasting this snippet into Shopify's Customer Events / Custom Pixel UI.
+const PIXEL_ID = 'PIXEL_ID';
+
+// Adapter for Shopify's async browser.cookie API. Naming is plain (_bhc / _bhp)
+// because Shopify storefronts aren't on beehiiv-owned domains, so the
+// host-suffix collision avoidance that DocumentCookieJar handles doesn't apply.
+class ShopifyCookieJar implements CookieJar {
+  async get(name: CookieName): Promise<string> {
+    return (await browser.cookie.get(name)) || '';
+  }
+  async set(name: CookieName, value: string): Promise<void> {
+    await browser.cookie.set(name, value);
+  }
+}
+
+const cookies = new ShopifyCookieJar();
+
+async function ensureProfileId(): Promise<void> {
+  if (!(await cookies.get('_bhp'))) {
+    await cookies.set('_bhp', generateUUID());
+  }
+}
+
+async function captureClickIdFromUrl(url: string | undefined): Promise<void> {
+  if (!url) return;
+  const clickId = parseClickId(url);
+  if (!clickId) return;
+  const existing = await cookies.get('_bhc');
+  if (existing !== clickId) {
+    await cookies.set('_bhc', clickId);
+  }
+}
+
+async function track(eventName: string, event: ShopifyEvent, data: TrackData): Promise<void> {
+  try {
+    const url = event.context?.document?.location?.href || '';
+    const userAgent = event.context?.navigator?.userAgent || '';
+
+    const payload = await buildPayload({
+      pixelId: PIXEL_ID,
+      eventName: eventName.toLowerCase(),
+      url,
+      userAgent,
+      scriptVersion: SCRIPT_VERSION,
+      cookies,
+      data,
+    });
+
+    await sendToApiary([payload]);
+  } catch (error) {
+    console.error('[bhpx-shopify] track failed:', error);
+  }
+}
+
+// page_viewed: every page navigation on the storefront. We use it to capture
+// ?bhcl_id=... on landing (writes _bhc) and to fire a pageview event.
+analytics.subscribe('page_viewed', async (event: ShopifyEvent) => {
+  await ensureProfileId();
+  await captureClickIdFromUrl(event.context?.document?.location?.href);
+  await track('pageview', event, {});
+});
+
+// checkout_completed: the conversion event. _bhc was set by page_viewed when
+// the user landed from a beehiiv ad, so attribution flows through unchanged.
+analytics.subscribe('checkout_completed', async (event: ShopifyEvent) => {
+  const checkout = event.data?.checkout;
+  await track('purchase', event, {
+    order_id: checkout?.order?.id,
+    email: checkout?.email,
+    currency: checkout?.currencyCode,
+    value_cents: checkout?.totalPrice?.amount
+      ? Math.round(checkout.totalPrice.amount * 100)
+      : undefined,
+  });
+});

--- a/src/pixel-v2.ts
+++ b/src/pixel-v2.ts
@@ -1,21 +1,18 @@
-import { md5 } from 'js-md5';
 import { version as SCRIPT_VERSION } from '../package.json';
+import { DocumentCookieJar, getHostDomain, parseClickId } from './lib/cookies';
+import { dedupe } from './lib/dedupe';
+import { buildPayload } from './lib/payload';
+import { sendToApiary } from './lib/transport';
+import type { InitOptions, PixelPayload, TrackOptions } from './lib/types';
+import { generateUUID, isCrawler, validatePixelId } from './lib/utils';
 
-// Extend Window interface for our globals
 declare global {
   interface Window {
     bhpx: BeehiivPixelQueue;
-    bhp?: {
-      track: typeof track;
-    };
-    ReactRouter?: unknown;
-    React?: {
-      useEffect: (...args: unknown[]) => unknown;
-    };
+    bhp?: { track: typeof track };
   }
 }
 
-// Types
 interface BeehiivPixelQueue {
   queue?: unknown[][];
   callMethod?: (...args: unknown[]) => void;
@@ -31,493 +28,80 @@ interface DebugUtils {
   log: (message: string) => void;
 }
 
-interface HostDomain {
-  host: string;
-  domain: string;
-}
-
-interface TrackOptions {
-  pixelId?: string;
-  data?: TrackData;
-}
-
-interface TrackData {
-  content_category?: string;
-  content_ids?: string[];
-  content_name?: string;
-  content_type?: string;
-  currency?: string;
-  num_items?: number;
-  predicted_ltv_cents?: number | string;
-  search_string?: string;
-  status?: string;
-  value_cents?: number | string;
-  order_id?: string;
-  email?: string;
-}
-
-interface PixelPayload {
-  pixel_id: string;
-  ad_network_placement_id: string;
-  subscriber_id: string;
-  profile_id: string;
-  event: string;
-  timestamp: number;
-  landed_timestamp: number;
-  sent_timestamp: number;
-  event_id: string;
-  url: string;
-  user_agent: string;
-  script_version: string;
-  content_category?: string;
-  content_ids?: string[];
-  content_name?: string;
-  content_type?: string;
-  currency?: string;
-  num_items?: number;
-  predicted_ltv_cents?: number;
-  search_string?: string;
-  status?: string;
-  value_cents?: number;
-  email_hash_sha256: string;
-  email_hash_sha1: string;
-  email_hash_md5: string;
-  order_id?: string;
-  email_address_id?: string;
-}
-
-interface EmailHashes {
-  email_hash_sha256: string;
-  email_hash_sha1: string;
-  email_hash_md5: string;
-}
-
-interface InitOptions {
-  autoConfig?: boolean;
-  debug?: boolean;
-  disableDedupe?: boolean;
-  trackClientNavigation?: boolean;
-  batchSize?: number;
-  batchInterval?: number;
-  retryAttempts?: number;
-}
-
-interface ProcessedEvents {
-  [hash: string]: number;
-}
-
-// Get the queue that was created by the base script
 const bhpx = window.bhpx;
 const queue = bhpx.queue || [];
 
-let _pixelId = ''; // pixelId will be set during initialization
-const isSecure = true;
+let _pixelId = '';
+let _cookies: DocumentCookieJar | null = null;
+let _initPromise: Promise<void> | null = null;
 
-// Configuration
-const APIARY_ENDPOINT = import.meta.env.VITE_PIXEL_V2_APIARY_ENDPOINT as string;
-const EXCLUDED_DOMAINS = ['beehiiv.com', 'staginghiiv.com', 'localhiiv.com'];
 const CONFIG = {
-  RETRY_ATTEMPTS: 3,
-  RETRY_DELAY: 1000,
-  REQUEST_TIMEOUT: 5000,
-  RATE_LIMIT_INTERVAL: 0,
   BATCH_SIZE: 1,
   BATCH_INTERVAL: 1000,
-  DEDUPE_TIME_PERIOD: 15 * 60, // 15 minutes in seconds
   DISABLE_DEDUPE: false,
   DEBUG: false,
 };
 
-// Debug logger — silent by default, enable via init({ debug: true })
 function debugLog(...args: unknown[]): void {
   if (CONFIG.DEBUG) {
     console.log('[bhpx]', ...args);
   }
 }
 
-// Rate limiter implementation
-const rateLimiter = {
-  lastEvent: 0,
-  minInterval: CONFIG.RATE_LIMIT_INTERVAL,
-  canTrack(): boolean {
-    const now = Date.now();
-    if (now - this.lastEvent >= this.minInterval) {
-      this.lastEvent = now;
-      return true;
-    }
-    return false;
-  },
-};
-
-// Event batching
 const eventQueue: PixelPayload[] = [];
 let batchTimeout: ReturnType<typeof setTimeout> | null = null;
 
-// Utility Functions
-function isCrawler(): boolean {
-  const ua = navigator.userAgent.toLowerCase();
-  const crawlerRegex =
-    /(bot|crawl|spider|slurp|archiver|indexer|facebookexternalhit|twitterbot|bingpreview|applebot|siteaudit|semrush|ahrefs|mj12bot|seznambot|screaming frog|dotbot)/i;
-  return crawlerRegex.test(ua);
+// Resolved once init() completes its async cookie writes. Track gates on this
+// so the GTM template's tight `init → track → track → track` loop can't fire
+// events before _bhc/_bhp are written. See template.tpl line 345-355.
+function isInitialized(): Promise<void> {
+  if (!_initPromise) {
+    throw new Error('Pixel not initialized — call bhpx("init", "PIXEL_ID") first');
+  }
+  return _initPromise;
 }
 
-function generateUUID(): string {
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-    const r = (Math.random() * 16) | 0;
-    const v = c === 'x' ? r : (r & 0x3) | 0x8;
-    return v.toString(16);
-  });
-}
-
-function getHostDomain(): HostDomain {
-  const { hostname } = window.location;
-  if (hostname === 'localhost' || hostname === '127.0.0.1') return { host: '', domain: 'localhost' };
-  let host = 'www';
-  let domain = '';
-  const parts = hostname.split('.');
-  if (parts.length < 3) {
-    domain = `${parts[0]}.${parts[1]}`;
-  } else {
-    host = parts[0];
-    domain = `${parts[1]}.${parts[2]}`;
-  }
-  return { host, domain };
-}
-
-async function sendToServer(payload: PixelPayload[], retryAttempt = 0): Promise<void> {
-  if (!rateLimiter.canTrack()) {
-    console.warn('Rate limit exceeded, skipping event');
-    return;
-  }
-
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), CONFIG.REQUEST_TIMEOUT);
-
-  try {
-    navigator.sendBeacon(APIARY_ENDPOINT, JSON.stringify(payload));
-  } catch (error) {
-    if (error instanceof Error && error.name === 'AbortError') {
-      console.error('Request timed out');
-    }
-
-    if (retryAttempt < CONFIG.RETRY_ATTEMPTS) {
-      await new Promise((resolve) => setTimeout(resolve, CONFIG.RETRY_DELAY * (retryAttempt + 1)));
-      return sendToServer(payload, retryAttempt + 1);
-    }
-
-    throw error;
-  } finally {
-    clearTimeout(timeoutId);
-  }
-}
-
-function validatePixelId(pixelId: string): boolean {
-  if (!pixelId || typeof pixelId !== 'string') {
-    throw new Error('Invalid pixel ID');
-  }
-  // Add specific format validation if needed
-  const pixelIdRegex = /^[a-zA-Z0-9-_]{8,}$/;
-  if (!pixelIdRegex.test(pixelId)) {
-    throw new Error('Invalid pixel ID format');
-  }
-  return true;
-}
-
-// Enhanced tracking with batching support
-async function track(eventName: string, options: TrackOptions = {}): Promise<void> {
-  try {
-    if (isCrawler()) {
-      // don't run the pixel for known crawlers
-      return;
-    }
-
-    // Use pixelId from options if provided, otherwise fall back to initialized _pixelId
-    const pixelId = options.pixelId || _pixelId;
-    debugLog(`track(): event=${eventName}, options.pixelId=${options.pixelId}, _pixelId=${_pixelId}, resolved pixelId=${pixelId}`);
-
-    if (!pixelId) {
-      debugLog('track(): no pixelId available!');
-      throw new Error('Pixel ID not initialized');
-    }
-
-    // Validate pixelId if provided in options
-    if (options.pixelId) {
-      validatePixelId(options.pixelId);
-    }
-    if (!eventName || typeof eventName !== 'string') {
-      throw new Error('Invalid event name');
-    }
-
-    // Normalize event name to lowercase
-    eventName = eventName.toLowerCase();
-    const event_id = generateUUID();
-    const timestamp = Date.now();
-    const { host, domain } = getHostDomain();
-    const bhc = getCookie('_bhc', host, domain) || '';
-    const bhp = getCookie('_bhp', host, domain) || '';
-    const [ad_network_placement_id, subscriber_id, email_address_id] = bhc.split('_');
-
-    const data = options.data || {};
-    const {
-      content_category,
-      content_ids,
-      content_name,
-      content_type,
-      currency,
-      num_items,
-      predicted_ltv_cents,
-      search_string,
-      status,
-      value_cents,
-      order_id,
-    } = data;
-
-    let email = data.email || '';
-    try {
-      const url = new URL(window.top?.location.href || window.location.href);
-      if (!email && url.searchParams.has('email')) {
-        email = url.searchParams.get('email') || '';
-      }
-    } catch {
-      // Ignore errors if URL parsing fails
-      // or if the URL is not accessible due to security restrictions
-    }
-
-    const debug = window.bhpx?.debug;
-    if (debug && typeof debug === 'object' && 'log' in debug) {
-      debug.log(`track: ${eventName} ${JSON.stringify(data)}`);
-    }
-
-    const { email_hash_sha256, email_hash_sha1, email_hash_md5 } = await hashEmail(email);
-
-    const payload: PixelPayload = {
-      pixel_id: pixelId,
-      ad_network_placement_id: ad_network_placement_id || '',
-      subscriber_id: subscriber_id || '',
-      profile_id: bhp, // anonymous profile id
-      event: eventName,
-      timestamp,
-      landed_timestamp: timestamp,
-      sent_timestamp: timestamp,
-      event_id,
-      url: window.location.href,
-      user_agent: window.navigator.userAgent,
-      script_version: SCRIPT_VERSION,
-      // custom data properties are optional
-      content_category,
-      content_ids,
-      content_name,
-      content_type,
-      currency,
-      num_items,
-      predicted_ltv_cents: getInt(predicted_ltv_cents),
-      search_string,
-      status,
-      value_cents: getInt(value_cents),
-      email_hash_sha256,
-      email_hash_sha1,
-      email_hash_md5,
-      order_id,
-      email_address_id,
-    };
-
-    // Add to batch queue
-    debugLog(`track(): adding to eventQueue, current length=${eventQueue.length}, BATCH_SIZE=${CONFIG.BATCH_SIZE}`);
-    eventQueue.push(payload);
-    debugLog(`track(): eventQueue length after push=${eventQueue.length}, batchTimeout=${batchTimeout ? 'active' : 'null'}`);
-
-    // Set up batch processing if not already scheduled
-    if (!batchTimeout && eventQueue.length < CONFIG.BATCH_SIZE) {
-      debugLog(`track(): scheduling batch in ${CONFIG.BATCH_INTERVAL}ms`);
-      batchTimeout = setTimeout(processBatch, CONFIG.BATCH_INTERVAL);
-    } else if (eventQueue.length >= CONFIG.BATCH_SIZE) {
-      debugLog('track(): batch size reached, processing immediately');
-      await processBatch();
-    }
-  } catch (error) {
-    console.error('Tracking failed:', error);
-    if (window.bhpx.debug) {
-      console.error('Debug details:', { eventName, options });
-    }
-  }
-}
-
-async function processBatch(): Promise<void> {
-  debugLog(`processBatch(): eventQueue length=${eventQueue.length}`);
-  if (eventQueue.length === 0) return;
-
-  const batch = dedupe(eventQueue.splice(0, CONFIG.BATCH_SIZE));
-  debugLog(`processBatch(): after dedupe, batch length=${batch.length}`);
-  // If no events left after deduplication, exit early
-  if (batch.length === 0) return;
-
-  batchTimeout = null;
-
-  try {
-    debugLog(`processBatch(): sending ${batch.length} event(s) to server`, batch.map(e => ({ event: e.event, pixel_id: e.pixel_id })));
-    sendToServer(batch);
-  } catch (error) {
-    console.error('Failed to process batch:', error);
-    // Optionally, re-queue failed events
-    eventQueue.unshift(...batch);
-  }
-}
-
-function dedupe(events: PixelPayload[]): PixelPayload[] {
-  if (CONFIG.DISABLE_DEDUPE) {
-    debugLog('dedupe: DISABLED — passing all events through');
-    return events;
-  }
-  const STORAGE_KEY = 'bhpx_processed_events';
-  const currentTime = Math.floor(Date.now() / 1000); // current time in seconds
-
-  // Load existing processed events from localStorage
-  let processedEvents: ProcessedEvents = {};
-  try {
-    const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored) {
-      processedEvents = JSON.parse(stored) as ProcessedEvents;
-    }
-  } catch (error) {
-    console.warn('Failed to load processed events from localStorage:', error);
-    processedEvents = {};
-  }
-
-  // Filter out events already processed within the dedupe time period
-  const seen = new Set<string>();
-  const filteredEvents = events.filter((event) => {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { timestamp, landed_timestamp, sent_timestamp, event_id, ...rest } = event;
-    const eventJson = JSON.stringify(rest);
-    const eventHash = md5(eventJson);
-
-    // Check current batch
-    if (seen.has(eventHash)) {
-      const debug = window?.bhpx?.debug;
-      if (debug && typeof debug === 'object' && 'log' in debug) {
-        debug.log(`Event ${event_id} ${event.event} is a duplicate in the current batch and will be skipped.`);
-      }
-      return false;
-    }
-
-    // Check against previously processed events
-    if (processedEvents[eventHash]) {
-      const processedAt = processedEvents[eventHash];
-      const timeDiff = currentTime - processedAt;
-
-      if (timeDiff < CONFIG.DEDUPE_TIME_PERIOD) {
-        const debug = window?.bhpx?.debug;
-        if (debug && typeof debug === 'object' && 'log' in debug) {
-          debug.log(
-            `Event ${event_id} ${rest.event} is a duplicate since ${timeDiff} seconds ago and will be skipped.`,
-          );
-        }
-        return false;
-      }
-    }
-
-    seen.add(eventHash);
-    return true;
-  });
-
-  // Store newly processed events with timestamps
-  const updatedProcessedEvents: ProcessedEvents = { ...processedEvents };
-
-  // Add new events
-  filteredEvents.forEach((event) => {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { timestamp, landed_timestamp, sent_timestamp, event_id, ...rest } = event;
-    const eventJson = JSON.stringify(rest);
-    const eventHash = md5(eventJson);
-    updatedProcessedEvents[eventHash] = currentTime;
-  });
-
-  // Clean up expired events
-  Object.keys(updatedProcessedEvents).forEach((hash) => {
-    if (updatedProcessedEvents[hash] < currentTime - CONFIG.DEDUPE_TIME_PERIOD) {
-      delete updatedProcessedEvents[hash];
-    }
-  });
-
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(updatedProcessedEvents));
-  } catch (error) {
-    console.warn('Failed to save processed events to localStorage:', error);
-  }
-
-  return filteredEvents;
-}
-
-// Enhanced click handling with validation
-function handleClickIdentification(): void {
-  try {
-    const urlParams = new URLSearchParams(window.location.search);
-    const bhclId = urlParams.get('bhcl_id');
-
-    if (!bhclId) return;
-
-    // Validate bhclId format
-    const bhclIdRegex = /^[a-zA-Z0-9-_]{8,}$/;
-    if (!bhclIdRegex.test(bhclId)) {
-      console.error('Invalid bhcl_id format');
-      return;
-    }
-
-    const { host, domain } = getHostDomain();
-
-    const bhc = getCookie('_bhc', host, domain) || '';
-
-    // Check if bhclId is already stored
-    if (bhc === bhclId) {
-      return;
-    }
-    // Store click data
-    updateBHCCookie('_bhc', bhclId, host, domain);
-  } catch (error) {
-    console.error('Error in click identification:', error);
-  }
-}
-
-debugLog(`beehiiv pixel v${SCRIPT_VERSION} loaded`);
-
-// Enhanced initialization with validation and cleanup
-function init(pixelId: string, options: InitOptions = {}): void {
+async function init(pixelId: string, options: InitOptions = {}): Promise<void> {
   try {
     validatePixelId(pixelId);
+    // Set sync state immediately so subsequent track() calls have what they
+    // need even before the async cookie writes below complete.
     _pixelId = pixelId;
+
+    const { host, domain } = getHostDomain(window.location.hostname);
+    _cookies = new DocumentCookieJar(host, domain);
 
     debugLog(`beehiiv pixel v${SCRIPT_VERSION} initialized`);
 
-    const { host, domain } = getHostDomain();
-
-    // Set user identification cookie if not exists
-    if (!getCookie('_bhp', host, domain)) {
-      updateCookie('_bhp', generateUUID(), domain);
-    }
-
-    // Handle ad click identification
-    handleClickIdentification();
-
-    const defaultConfig: Required<InitOptions> = {
+    const config = {
       autoConfig: true,
       debug: false,
       disableDedupe: false,
       trackClientNavigation: true,
       batchSize: CONFIG.BATCH_SIZE,
       batchInterval: CONFIG.BATCH_INTERVAL,
-      retryAttempts: CONFIG.RETRY_ATTEMPTS,
+      ...options,
     };
 
-    const config = { ...defaultConfig, ...options };
-
-    // Update global config with user options
     Object.assign(CONFIG, {
       BATCH_SIZE: config.batchSize,
       BATCH_INTERVAL: config.batchInterval,
-      RETRY_ATTEMPTS: config.retryAttempts,
       DISABLE_DEDUPE: config.disableDedupe,
       DEBUG: config.debug,
     });
+
+    if (!(await _cookies.get('_bhp'))) {
+      await _cookies.set('_bhp', generateUUID());
+    }
+
+    const bhclId = parseClickId(window.location.href);
+    if (bhclId) {
+      const existing = await _cookies.get('_bhc');
+      if (existing !== bhclId) {
+        await _cookies.set('_bhc', bhclId);
+        debugLog(`bhcl_id captured: ${bhclId}`);
+      }
+    }
 
     if (config.trackClientNavigation) {
       monitorUrlChanges(() => track('pageview'));
@@ -528,26 +112,79 @@ function init(pixelId: string, options: InitOptions = {}): void {
     }
   } catch (error) {
     console.error('Initialization failed:', error);
+    throw error;
   }
 }
 
-// Process any commands that were queued before the pixel loaded
+async function track(eventName: string, options: TrackOptions = {}): Promise<void> {
+  try {
+    if (isCrawler()) return;
+
+    await isInitialized();
+
+    const pixelId = options.pixelId || _pixelId;
+    if (!pixelId) throw new Error('Pixel ID not initialized');
+    if (options.pixelId) validatePixelId(options.pixelId);
+    if (!eventName || typeof eventName !== 'string') {
+      throw new Error('Invalid event name');
+    }
+    if (!_cookies) throw new Error('Cookie jar not initialized');
+
+    const payload = await buildPayload({
+      pixelId,
+      eventName: eventName.toLowerCase(),
+      url: window.location.href,
+      userAgent: window.navigator.userAgent,
+      scriptVersion: SCRIPT_VERSION,
+      cookies: _cookies,
+      data: options.data || {},
+    });
+
+    const debug = window.bhpx?.debug;
+    if (debug && typeof debug === 'object' && 'log' in debug) {
+      debug.log(`track: ${eventName} ${JSON.stringify(options.data || {})}`);
+    }
+
+    eventQueue.push(payload);
+
+    if (!batchTimeout && eventQueue.length < CONFIG.BATCH_SIZE) {
+      batchTimeout = setTimeout(processBatch, CONFIG.BATCH_INTERVAL);
+    } else if (eventQueue.length >= CONFIG.BATCH_SIZE) {
+      await processBatch();
+    }
+  } catch (error) {
+    console.error('Tracking failed:', error);
+  }
+}
+
+async function processBatch(): Promise<void> {
+  if (eventQueue.length === 0) return;
+  const drained = eventQueue.splice(0, CONFIG.BATCH_SIZE);
+  const batch = CONFIG.DISABLE_DEDUPE ? drained : dedupe(drained);
+  batchTimeout = null;
+  if (batch.length === 0) return;
+  try {
+    await sendToApiary(batch);
+  } catch (error) {
+    console.error('Failed to process batch:', error);
+    eventQueue.unshift(...batch);
+  }
+}
+
+debugLog(`beehiiv pixel v${SCRIPT_VERSION} loaded`);
+
 bhpx.callMethod = (...rest: unknown[]): void => {
   const args = Array.prototype.slice.call(rest) as unknown[];
   const method = args[0] as string;
   const params = args.slice(1);
 
-  debugLog(`callMethod: method=${method}`, 'params:', params);
-
   switch (method) {
     case 'init': {
-      debugLog(`init: pixelId=${params[0]}`);
-      init(params[0] as string, params[1] as InitOptions);
+      _initPromise = init(params[0] as string, params[1] as InitOptions);
       break;
     }
     case 'track': {
       const trackFn = window.bhp?.track || track;
-      debugLog(`track: event=${params[0]}`, 'options:', params[1], 'using:', window.bhp?.track ? 'window.bhp.track' : 'track');
       trackFn(params[0] as string, params[1] as TrackOptions);
       break;
     }
@@ -557,48 +194,33 @@ bhpx.callMethod = (...rest: unknown[]): void => {
   }
 };
 
-// Process queued commands
-debugLog(`processing ${queue.length} queued command(s)`);
+// Drain any commands that the queue stub collected before this script loaded.
 while (queue.length > 0) {
   const cmd = queue.shift();
-  if (cmd) {
-    debugLog('dequeuing command:', cmd);
-    bhpx.callMethod.apply(null, cmd);
-  }
+  if (cmd) bhpx.callMethod.apply(null, cmd);
 }
 
-// Export for testing (if needed)
-export { track, init, generateUUID, getHostDomain, getCookie, validatePixelId, CONFIG };
+export { track, init, isInitialized, CONFIG };
 
 function monitorUrlChanges(onUrlChange: () => void): void {
-  // Save references to the original methods
   const originalPushState = history.pushState;
   const originalReplaceState = history.replaceState;
 
-  // Create a custom event to detect history changes
   function triggerUrlChangeEvent(): void {
-    const event = new Event('bhpx:urlchange');
-    window.dispatchEvent(event);
+    window.dispatchEvent(new Event('bhpx:urlchange'));
   }
 
-  // Override history.pushState
   history.pushState = function (...args: Parameters<typeof history.pushState>): void {
     originalPushState.apply(this, args);
-    triggerUrlChangeEvent(); // Trigger the custom event
+    triggerUrlChangeEvent();
   };
 
-  // Override history.replaceState
   history.replaceState = function (...args: Parameters<typeof history.replaceState>): void {
     originalReplaceState.apply(this, args);
-    triggerUrlChangeEvent(); // Trigger the custom event
+    triggerUrlChangeEvent();
   };
 
-  // Listen for popstate event
-  window.addEventListener('popstate', () => {
-    triggerUrlChangeEvent(); // Trigger the custom event
-  });
-
-  // Listen for the custom bhpx:urlchange event
+  window.addEventListener('popstate', triggerUrlChangeEvent);
   window.addEventListener('bhpx:urlchange', onUrlChange);
 }
 
@@ -608,52 +230,34 @@ function enableDebugMode(): void {
     group: 'color: #4a90e2; font-weight: bold; font-size: 12px;',
     event: 'color: #2ecc71; font-weight: bold;',
     params: 'color: #9b59b6;',
-    warning: 'color: #e67e22; font-weight: bold;',
-    error: 'color: #e74c3c; font-weight: bold;',
   };
 
-  // Create debug overlay
   const debugOverlay = document.createElement('div');
   debugOverlay.style.cssText = `
-        position: fixed;
-        bottom: 20px;
-        right: 20px;
-        background: rgba(0, 0, 0, 0.8);
-        color: white;
-        padding: 10px;
-        border-radius: 5px;
-        font-family: monospace;
-        font-size: 12px;
-        z-index: 9999;
-        max-height: 300px;
-        overflow-y: auto;
-        max-width: 400px;
-      `;
+    position: fixed; bottom: 20px; right: 20px;
+    background: rgba(0,0,0,0.8); color: white;
+    padding: 10px; border-radius: 5px;
+    font-family: monospace; font-size: 12px;
+    z-index: 9999; max-height: 300px; overflow-y: auto; max-width: 400px;
+  `;
   document.body.appendChild(debugOverlay);
 
   function logToOverlay(message: string): void {
-    console.log('logging to overlay', message);
     const entry = document.createElement('div');
-    entry.style.borderBottom = '1px solid rgba(255, 255, 255, 0.1)';
+    entry.style.borderBottom = '1px solid rgba(255,255,255,0.1)';
     entry.style.padding = '5px 0';
     entry.textContent = `${new Date().toISOString().slice(11, -1)} - ${message}`;
     debugOverlay.insertBefore(entry, debugOverlay.firstChild);
-
-    // Keep only last 50 entries
     if (debugOverlay.children.length > 50) {
       debugOverlay.removeChild(debugOverlay.lastChild!);
     }
   }
 
-  // Override the original track function
   const originalTrack = window.bhpx.track || track;
   window.bhpx.track = async function (eventName: string, params: TrackOptions = {}): Promise<void> {
-    // Console logging
     console.group('%cBeehiiv Pixel Debug', debugStyles.group);
     console.log(`%cEvent: ${eventName.toLowerCase()}`, debugStyles.event);
     console.log('%cParameters:', debugStyles.params, params);
-
-    // Add SPA-specific debug info
     console.log('%cRouting Info:', debugStyles.params, {
       pathname: window.location.pathname,
       search: window.location.search,
@@ -661,50 +265,11 @@ function enableDebugMode(): void {
       title: document.title,
       referrer: document.referrer,
     });
-
     console.groupEnd();
-
-    // Overlay logging
     logToOverlay(`${eventName} tracked - ${JSON.stringify(params)}`);
-
-    // Performance monitoring for SPA
-    const startTime = performance.now();
-
-    // Call original track function
     await originalTrack.apply(this, [eventName, params]);
-
-    const endTime = performance.now();
-    console.log(`%cTracking Performance: ${Math.round(endTime - startTime)}ms`, debugStyles.params);
   };
 
-  // Monitor History API calls
-  const debugHistory = (type: string, args: unknown[]): void => {
-    console.group('%cHistory API Debug', debugStyles.group);
-    console.log(`%c${type} called:`, debugStyles.event, {
-      state: args[0],
-      title: args[1],
-      url: args[2],
-    });
-    console.groupEnd();
-
-    logToOverlay(`History ${type}: ${args[2]}`);
-  };
-
-  // Override History API methods
-  const originalPushState = history.pushState;
-  const originalReplaceState = history.replaceState;
-
-  history.pushState = function (...args: Parameters<typeof history.pushState>): void {
-    debugHistory('pushState', args);
-    return originalPushState.apply(this, args);
-  };
-
-  history.replaceState = function (...args: Parameters<typeof history.replaceState>): void {
-    debugHistory('replaceState', args);
-    return originalReplaceState.apply(this, args);
-  };
-
-  // Export debug utilities to window for console access
   window.bhpx.debug = {
     overlay: debugOverlay,
     clearLogs: () => {
@@ -713,105 +278,12 @@ function enableDebugMode(): void {
     toggleOverlay: () => {
       debugOverlay.style.display = debugOverlay.style.display === 'none' ? 'block' : 'none';
     },
-    getEventHistory: () => {
-      return Array.from(debugOverlay.children).map((child) => child.textContent || '');
-    },
+    getEventHistory: () => Array.from(debugOverlay.children).map((c) => c.textContent || ''),
     log: logToOverlay,
   };
 
-  console.log('%cBeehiiv Pixel Debug Mode Enabled', 'color: #4a90e2; font-size: 14px; font-weight: bold;');
-  console.log('Debug utilities available via window.bhpx.debug', window.bhpx.debug);
-}
-
-function getInt(s: number | string | undefined): number | undefined {
-  if (typeof s === 'number') return s;
-  if (typeof s === 'string') return Number.parseInt(s, 10);
-  return undefined;
-}
-
-function findCookieWithHost(name: string, host: string, domain: string): [string | undefined, string] {
-  const allCookies = document.cookie.split(';');
-  let cookie: string | undefined;
-  const isExcludedDomain = EXCLUDED_DOMAINS.includes(domain);
-
-  if (!isExcludedDomain) {
-    cookie = findCookie(allCookies, name);
-  }
-  if (!cookie) {
-    name = `${name}_${host}`;
-    cookie = findCookie(allCookies, name);
-  }
-  if (!cookie && host !== 'www') {
-    name = `${name}_www`;
-    cookie = findCookie(allCookies, name);
-  }
-  return [cookie, name];
-}
-
-function getCookieValue(cookie: string): string {
-  return cookie ? cookie.split('=')[1] : '';
-}
-
-function getCookie(name: string, host: string, domain: string): string {
-  const [cookie] = findCookieWithHost(name, host, domain);
-  if (cookie) {
-    return getCookieValue(cookie);
-  }
-  return '';
-}
-
-function updateBHCCookie(name: string, value: string, host: string, domain: string): void {
-  const isExcludedDomain = EXCLUDED_DOMAINS.includes(domain);
-  if (isExcludedDomain) {
-    // append host to beehiiv domains
-    name = `${name}_${host}`;
-  }
-  updateCookie(name, value, domain);
-  debugLog(`bhcl_id added to cookie: ${name}`);
-}
-
-function updateCookie(name: string, value: string, domain: string): void {
-  const expires = 365 * 24 * 60 * 60;
-  const cookieProps = `domain=.${domain}; path=/; samesite=strict; ${isSecure ? 'secure;' : ''} max-age=${expires}`;
-  document.cookie = `${name}=${value}; ${cookieProps}`;
-}
-
-function findCookie(allCookies: string[], name: string): string | undefined {
-  return allCookies.find((cookie) => cookie.trim().startsWith(`${name}=`));
-}
-
-async function hashEmail(email: string): Promise<EmailHashes> {
-  if (!email) {
-    return { email_hash_sha256: '', email_hash_sha1: '', email_hash_md5: '' };
-  }
-  return await promiseAllObject({
-    email_hash_sha256: generateHash(email, 'SHA-256'),
-    email_hash_sha1: generateHash(email, 'SHA-1'),
-    email_hash_md5: Promise.resolve(md5(email)),
-  });
-}
-
-async function generateHash(input: string, algorithm: AlgorithmIdentifier): Promise<string> {
-  // Convert input string to ArrayBuffer
-  const msgBuffer = new TextEncoder().encode(input);
-  // Generate hash
-  const hashBuffer = await crypto.subtle.digest(algorithm, msgBuffer);
-  // Convert to hexadecimal string
-  const hashArray = Array.from(new Uint8Array(hashBuffer));
-  return hashArray.map((byte) => byte.toString(16).padStart(2, '0')).join('');
-}
-
-async function promiseAllObject<T extends Record<string, Promise<string>>>(
-  promisesObj: T,
-): Promise<{ [K in keyof T]: string }> {
-  const keys = Object.keys(promisesObj) as (keyof T)[];
-  const promises = Object.values(promisesObj);
-  const results = await Promise.all(promises);
-  return keys.reduce(
-    (obj, key, index) => {
-      obj[key] = results[index];
-      return obj;
-    },
-    {} as { [K in keyof T]: string },
+  console.log(
+    '%cBeehiiv Pixel Debug Mode Enabled',
+    'color: #4a90e2; font-size: 14px; font-weight: bold;',
   );
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,6 +21,21 @@ export default defineConfig(({ mode }) => {
         name: globalName,
         fileName: () => `${entryName}.js`,
       },
+      rollupOptions: {
+        output: {
+          // For pixel-shopify, inject the PIXEL_ID placeholder at the very top
+          // of the IIFE body — right after `use strict` and the inlined
+          // `version` constant — so the advertiser can spot it immediately
+          // when they open dist/pixel-shopify.js to paste into Shopify's
+          // Customer Events UI. The intro is wrapped in a banner comment to
+          // call attention to it. Source declares it as `declare const` so
+          // TypeScript is happy without emitting a duplicate.
+          intro:
+            entryName === 'pixel-shopify'
+              ? "  // ─── REPLACE 'PIXEL_ID' BELOW WITH YOUR BEEHIIV PIXEL ID ───\n  const pixelId = 'PIXEL_ID';\n"
+              : undefined,
+        },
+      },
     },
   };
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,9 @@ import { defineConfig } from 'vite';
 
 export default defineConfig(({ mode }) => {
   const entryName = process.env.VITE_BUILD_ENTRY || 'pixel-v2'; // Default to pixel-v2
-  const globalName = entryName.replace('-', '_'); // Convert pixel-v1 to pixel_v1 for global name
+  const globalName = entryName.replace(/-/g, '_'); // Convert pixel-v1 to pixel_v1 for global name
+  // pixel-js is legacy JavaScript; everything else is TypeScript
+  const ext = entryName === 'pixel-js' ? '.js' : '.ts';
   console.log(`Building ${entryName} with global name ${globalName} in ${mode} mode`);
   return {
     define: {
@@ -14,8 +16,7 @@ export default defineConfig(({ mode }) => {
       minify: false,
       target: 'esnext',
       lib: {
-        // pixel-v2 is TypeScript, pixel-js is JavaScript
-        entry: `./src/${entryName}${entryName === 'pixel-v2' ? '.ts' : '.js'}`,
+        entry: `./src/${entryName}${ext}`,
         formats: ['iife'],
         name: globalName,
         fileName: () => `${entryName}.js`,


### PR DESCRIPTION
# Summary

**TL;DR** Shopify's Customer Events sandbox can't read storefront cookies — which means the old "drop `pixel-v2.js` into a Custom Pixel" approach was firing `purchase` events without attribution and we never noticed. This PR fixes it with a two-halves architecture (`theme.liquid` for click capture, `pixel-shopify.js` for checkout firing), a shared lib that prevents the two halves from drifting apart, and defensive payload validation that catches both unsubstituted click-URL template placeholders and floating-point `value_cents` drift in ingestion.

Closes BEE-19449.

## The Full Story 🔍
<details>

### How we got here

An advertiser (Stensul) flagged that beehiiv `purchase` events were arriving in their pipeline but with empty `subscriber_id` / `ad_network_placement_id` / `email_address_id`. Their analysis was correct: the Shopify Custom Pixel runs in an isolated sandbox iframe — `document.cookie` reflects the sandbox's cookie jar, not the storefront's, and `window.location` is the sandbox URL, not the page the customer is actually on. Our `pixel-v2.js` synchronously reads `document.cookie`, so when it ran inside the sandbox, `_bhc` and `_bhp` were always empty. The beacon was firing; attribution was silently broken.

The original SHOPIFY guide instructed advertisers to do exactly that — paste `pixel-v2.js` into the Custom Pixel. I'd "tested" it once when writing the guide, but in hindsight I only confirmed that the beacon was being sent, not that the payload contained valid attribution data. So this PR is partly atonement.

### Invariants this PR has to protect

1. **A `purchase` event fired from inside Shopify's sandbox must carry the same `ad_network_placement_id` / `subscriber_id` / `email_address_id` as a `purchase` fired from a normal page.** If the storefront set `_bhc` on landing from a beehiiv ad, the conversion event has to be linkable back to that click — otherwise advertisers can't see beehiiv-attributed revenue.
2. **Payload schema can never drift between `pixel-v2` and `pixel-shopify`.** The two scripts are deployed independently — one via S3+CDN, the other via copy-paste into Shopify — so a field added in one and forgotten in the other would silently break attribution for half the install base.
3. **A malformed `_bhc` cookie (e.g., unsubstituted `{SUBSCRIBER}_{ID}` template placeholders from a broken ad URL) cannot cause backend rejection.** We saw real ingestion logs with literal `"SUBSCRIBER"` / `"ID"` strings making it into `subscriber_id`, failing the backend's UUID validator. Partial attribution should still flow if at least the placement UUID is valid.
4. **Floating-point `value_cents` like `32.63 * 100 = 3263.0000000000005` cannot reach the backend's decimal validator.** This rejected thousands of legitimate `initiate_checkout` events in production.

### The architecture

Two halves, shared core:

- **`theme.liquid` snippet** runs in the real storefront context. Loads `pixel-v2.js` from S3, captures `?bhcl_id=...` on landing, writes `_bhc`/`_bhp` to the storefront cookie jar, fires pageviews.
- **`pixel-shopify.js` Custom Pixel** runs in the sandbox. Reads `_bhc`/`_bhp` via Shopify's `browser.cookie` API (which is the only sandbox-safe path to storefront cookies), fires `purchase` on `checkout_completed`.
- **`src/lib/*`** is a shared core both entry points consume — `buildPayload`, `sendToApiary`, cookie validation, email hashing, the supported-events allowlist. The payload contract is defined once in `types.ts`, so the two halves cannot drift.

Two design decisions worth calling out:

- **`init()` is async and `track()` awaits `isInitialized()`.** The GTM template fires `init → track → track → track` in a tight synchronous loop (see `template.tpl:345-355`); without the gate, the first few `track()` calls would race the cookie writes from `init()` and ship payloads with empty `_bhp`. The promise is captured into a module-level `_initPromise` on the first `init` call and awaited by every subsequent `track`.
- **`CookieJar` is an `async` interface even though `DocumentCookieJar` reads are sync.** That sounds wasteful but it lets `pixel-shopify.ts` use the same `buildPayload` as `pixel-v2.ts` without forking the function — Shopify's `browser.cookie.get/set` is genuinely async, so the interface has to be async-shaped. The sync jar just wraps reads in resolved promises; the cost is one microtask per cookie access.

### Defensive validation

`buildPayload` now strips `_bhc` segments that don't match a UUID regex. So a cookie like `<valid-uuid>_SUBSCRIBER_ID` (template placeholders never substituted upstream) attributes the valid placement and drops the garbage trailing segments — instead of the backend rejecting the entire event because `subscriber_id: "SUBSCRIBER"` isn't a UUID. Partial attribution beats no attribution.

`getInt()` was passing native JS numbers through unchanged, so `32.63 * 100` reached the wire as `3263.0000000000005`. Now it `Math.round`s the number branch and `NaN`-guards the string branch. We saw thousands of these per day for `initiate_checkout` events from CBDistillery alone.

### Field-driven additions

After we shipped a beta to Adam at Stensul, his version included a `SUPPORTED_BEEHIIV_EVENTS` allowlist that ours didn't have. He'd added it himself to standardize what gets reported. We've adopted the same pattern — the canonical list lives in `src/lib/events.ts` and both `track()` paths gate on it. Apiary doesn't reject unknown events today, but standardizing client-side keeps reporting honest and catches typos before they ship bad telemetry.

Also moved the `PIXEL_ID` placeholder to the top of the built bundle (next to `version`) via Rollup's `output.intro` hook, so advertisers can spot it the moment they open `dist/pixel-shopify.js` in Shopify's Customer Events UI. Variable is named `pixelId` (camelCase) but the placeholder string stays `'PIXEL_ID'` (uppercase) — a find-and-replace of `PIXEL_ID` only swaps the value, never the variable.

### Why the old approach didn't just need a docs fix

Anyone reading the old SHOPIFY guide today would conclude: "drop `pixel-v2.js` into the Custom Pixel, profit." That recipe is technically possible — the beacon fires — but it ships zero attribution, which is worse than not having a Shopify integration at all. We needed working code first, then a guide that documents it accurately. The new `SHOPIFY.md` leads with *why* two halves are required (CSP, cookie isolation, sandbox URL context) so the next advertiser doesn't have to discover this independently.

### Tested end-to-end

Verified on the beehiiv demo Shopify site with a synthetic pixel_id. All attribution fields populate correctly:
- `_bhc` set on storefront landing from a beehiiv ad URL
- `_bhp` generated on first visit, stable across navigation
- `purchase` event in checkout carries `ad_network_placement_id` / `subscriber_id` / `email_address_id` / `email_hash_sha256` / hashed email — verified by inspecting the actual JSON payload landing in ingestion

### Dropped along the way

- **`js-md5` dependency.** We were using it for event dedupe hashing. Replaced with djb2 (5 lines of code) since browsers don't have native MD5 and SHA-256 is overkill for dedupe. -1 dependency, -1 lockfile entry.
- **The `email_hash_md5` field** in payloads. Ad team confirmed it's not used downstream, and we shouldn't be shipping MD5 hashes of emails in 2026 anyway.

### Deployment notes

- `pixel-v2.js` (the S3-hosted script consumed by `theme.liquid` snippets and GTM tags) — push to S3 via `pnpm upload` when you're ready to roll out.
- `pixel-shopify.js` (the Customer Events paste-in) — not S3-hosted by design. Advertisers paste the contents of `dist/pixel-shopify.js` directly into Shopify's Custom Pixel UI. Updates require they re-paste; we can't push updates to them remotely.

This is a clean break from the old `pixel-v2`-only approach. Per repo convention, no compat shim — the old guide's recipe never produced correct attribution, so preserving it would be preserving a bug.

</details>

---
From Claudia with 💙
