### PR TITLE
fix(pixel): sanitize payload to conform to Apiary's strict validation [BEE-20086]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pixel-v2",
   "private": true,
-  "version": "2.2.3",
+  "version": "2.2.4",
   "type": "module",
   "module": "./dist/pixel-v2.js",
   "scripts": {

--- a/src/lib/payload.ts
+++ b/src/lib/payload.ts
@@ -1,7 +1,15 @@
 import type { CookieJar } from './cookies';
 import { hashEmail } from './email-hash';
 import type { PixelPayload, TrackData } from './types';
-import { generateUUID, getInt, isValidUUID, toIdString, toStringArray } from './utils';
+import {
+  generateUUID,
+  getInt,
+  isValidUUID,
+  toIdString,
+  toStringArray,
+  toStringField,
+  warnIfChanged,
+} from './utils';
 
 export interface BuildPayloadContext {
   pixelId: string;
@@ -16,6 +24,12 @@ export interface BuildPayloadContext {
 // Builds the canonical pixel payload from an event context. Both pixel-v2
 // (direct injection) and pixel-shopify (sandbox) funnel through this so the
 // payload schema can't drift between environments.
+//
+// Sanitization philosophy: be lenient with what callers send (Shopify hands
+// us scalars, GTM hands us strings-pretending-to-be-numbers, etc.) but ship
+// Apiary exactly what it expects. Coerce silently when the meaning is
+// preserved; warn-and-drop only when the data is truly garbage (objects
+// where a primitive belongs, NaN, empty strings).
 export async function buildPayload(ctx: BuildPayloadContext): Promise<PixelPayload> {
   const event_id = generateUUID();
   const timestamp = Date.now();
@@ -44,6 +58,31 @@ export async function buildPayload(ctx: BuildPayloadContext): Promise<PixelPaylo
 
   const { email_hash_sha256, email_hash_sha1 } = await hashEmail(email);
 
+  const d = ctx.data;
+  const content_category = toStringField(d.content_category);
+  const content_ids = toStringArray(d.content_ids);
+  const content_name = toStringField(d.content_name);
+  const content_type = toStringField(d.content_type);
+  const currency = toStringField(d.currency);
+  const num_items = getInt(d.num_items);
+  const predicted_ltv_cents = getInt(d.predicted_ltv_cents);
+  const search_string = toStringField(d.search_string);
+  const status = toStringField(d.status);
+  const value_cents = getInt(d.value_cents);
+  const order_id = toIdString(d.order_id);
+
+  warnIfChanged('content_category', d.content_category, content_category);
+  warnIfChanged('content_ids', d.content_ids, content_ids);
+  warnIfChanged('content_name', d.content_name, content_name);
+  warnIfChanged('content_type', d.content_type, content_type);
+  warnIfChanged('currency', d.currency, currency);
+  warnIfChanged('num_items', d.num_items, num_items);
+  warnIfChanged('predicted_ltv_cents', d.predicted_ltv_cents, predicted_ltv_cents);
+  warnIfChanged('search_string', d.search_string, search_string);
+  warnIfChanged('status', d.status, status);
+  warnIfChanged('value_cents', d.value_cents, value_cents);
+  warnIfChanged('order_id', d.order_id, order_id);
+
   return {
     pixel_id: ctx.pixelId,
     ad_network_placement_id,
@@ -57,19 +96,19 @@ export async function buildPayload(ctx: BuildPayloadContext): Promise<PixelPaylo
     url: ctx.url,
     user_agent: ctx.userAgent,
     script_version: ctx.scriptVersion,
-    content_category: ctx.data.content_category,
-    content_ids: toStringArray(ctx.data.content_ids),
-    content_name: ctx.data.content_name,
-    content_type: ctx.data.content_type,
-    currency: ctx.data.currency,
-    num_items: ctx.data.num_items,
-    predicted_ltv_cents: getInt(ctx.data.predicted_ltv_cents),
-    search_string: ctx.data.search_string,
-    status: ctx.data.status,
-    value_cents: getInt(ctx.data.value_cents),
+    content_category,
+    content_ids,
+    content_name,
+    content_type,
+    currency,
+    num_items,
+    predicted_ltv_cents,
+    search_string,
+    status,
+    value_cents,
     email_hash_sha256,
     email_hash_sha1,
-    order_id: toIdString(ctx.data.order_id),
+    order_id,
     email_address_id,
   };
 }

--- a/src/lib/payload.ts
+++ b/src/lib/payload.ts
@@ -1,7 +1,7 @@
 import type { CookieJar } from './cookies';
 import { hashEmail } from './email-hash';
 import type { PixelPayload, TrackData } from './types';
-import { generateUUID, getInt, isValidUUID } from './utils';
+import { generateUUID, getInt, isValidUUID, toIdString, toStringArray } from './utils';
 
 export interface BuildPayloadContext {
   pixelId: string;
@@ -58,7 +58,7 @@ export async function buildPayload(ctx: BuildPayloadContext): Promise<PixelPaylo
     user_agent: ctx.userAgent,
     script_version: ctx.scriptVersion,
     content_category: ctx.data.content_category,
-    content_ids: ctx.data.content_ids,
+    content_ids: toStringArray(ctx.data.content_ids),
     content_name: ctx.data.content_name,
     content_type: ctx.data.content_type,
     currency: ctx.data.currency,
@@ -69,7 +69,7 @@ export async function buildPayload(ctx: BuildPayloadContext): Promise<PixelPaylo
     value_cents: getInt(ctx.data.value_cents),
     email_hash_sha256,
     email_hash_sha1,
-    order_id: ctx.data.order_id,
+    order_id: toIdString(ctx.data.order_id),
     email_address_id,
   };
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -3,7 +3,7 @@
 
 export interface TrackData {
   content_category?: string;
-  content_ids?: string[];
+  content_ids?: string | number | (string | number)[];
   content_name?: string;
   content_type?: string;
   currency?: string;
@@ -12,7 +12,7 @@ export interface TrackData {
   search_string?: string;
   status?: string;
   value_cents?: number | string;
-  order_id?: string;
+  order_id?: string | number;
   email?: string;
 }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -33,12 +33,15 @@ export function isValidUUID(s: string | undefined): boolean {
 // content_ids must ship as an array of strings. Shopify (and some GTM datalayer
 // configs) hand us a single scalar variant id — wrapping it here keeps the
 // backend's array validator happy without forcing every caller to remember.
+// Anything that stringifies to "[object Object]" is dropped — that's not a
+// real id, it's a misconfigured datalayer.
 export function toStringArray(v: unknown): string[] | undefined {
   if (v === undefined || v === null) return undefined;
   const arr = Array.isArray(v) ? v : [v];
   const out = arr
     .filter((x) => x !== undefined && x !== null && x !== '')
-    .map((x) => String(x));
+    .map((x) => String(x))
+    .filter((s) => s !== '[object Object]' && s.trim() !== '');
   return out.length ? out : undefined;
 }
 
@@ -47,7 +50,32 @@ export function toStringArray(v: unknown): string[] | undefined {
 // expected field type" until we coerce.
 export function toIdString(v: unknown): string | undefined {
   if (v === undefined || v === null || v === '') return undefined;
-  return String(v);
+  const s = String(v);
+  return s === '[object Object]' ? undefined : s;
+}
+
+// Coerce primitives to a trimmed non-empty string. Used for optional payload
+// fields where Apiary expects a string — content_category, content_name,
+// content_type, currency, search_string, status. Objects/arrays come back
+// as undefined since they have no sensible string projection here.
+export function toStringField(v: unknown): string | undefined {
+  if (v === undefined || v === null) return undefined;
+  if (typeof v === 'object') return undefined;
+  const s = String(v).trim();
+  return s.length ? s : undefined;
+}
+
+// Warn (without throwing) when our coercion actually changed the caller's
+// input. Lets advertisers spot misconfigured datalayers in devtools instead
+// of silently shipping massaged data forever.
+export function warnIfChanged(field: string, before: unknown, after: unknown): void {
+  if (before === after) return;
+  if (before === undefined || before === '') return;
+  // Deep-equal arrays of primitives — cheap and good enough for our shapes.
+  if (Array.isArray(before) && Array.isArray(after)) {
+    if (before.length === after.length && before.every((v, i) => v === after[i])) return;
+  }
+  console.warn(`[bhpx] ${field}: coerced ${JSON.stringify(before)} → ${JSON.stringify(after)}`);
 }
 
 export function validatePixelId(pixelId: string): boolean {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -30,6 +30,26 @@ export function isValidUUID(s: string | undefined): boolean {
   return !!s && UUID_RE.test(s);
 }
 
+// content_ids must ship as an array of strings. Shopify (and some GTM datalayer
+// configs) hand us a single scalar variant id — wrapping it here keeps the
+// backend's array validator happy without forcing every caller to remember.
+export function toStringArray(v: unknown): string[] | undefined {
+  if (v === undefined || v === null) return undefined;
+  const arr = Array.isArray(v) ? v : [v];
+  const out = arr
+    .filter((x) => x !== undefined && x !== null && x !== '')
+    .map((x) => String(x));
+  return out.length ? out : undefined;
+}
+
+// Cast to string. Backend expects order_id as a string but Shopify hands us
+// numeric ids (e.g. 4138434) — those rejected with "is not compatible with the
+// expected field type" until we coerce.
+export function toIdString(v: unknown): string | undefined {
+  if (v === undefined || v === null || v === '') return undefined;
+  return String(v);
+}
+
 export function validatePixelId(pixelId: string): boolean {
   if (!pixelId || typeof pixelId !== 'string') {
     throw new Error('Invalid pixel ID');

--- a/src/pixel-v2.ts
+++ b/src/pixel-v2.ts
@@ -1,6 +1,7 @@
 import { version as SCRIPT_VERSION } from '../package.json';
 import { DocumentCookieJar, getHostDomain, parseClickId } from './lib/cookies';
 import { dedupe } from './lib/dedupe';
+import { SUPPORTED_EVENTS, isSupportedEvent } from './lib/events';
 import { buildPayload } from './lib/payload';
 import { sendToApiary } from './lib/transport';
 import type { InitOptions, PixelPayload, TrackOptions } from './lib/types';
@@ -130,9 +131,17 @@ async function track(eventName: string, options: TrackOptions = {}): Promise<voi
     }
     if (!_cookies) throw new Error('Cookie jar not initialized');
 
+    const normalized = eventName.toLowerCase();
+    if (!isSupportedEvent(normalized)) {
+      console.warn(
+        `[bhpx] unsupported event "${eventName}" — must be one of: ${SUPPORTED_EVENTS.join(', ')}`,
+      );
+      return;
+    }
+
     const payload = await buildPayload({
       pixelId,
-      eventName: eventName.toLowerCase(),
+      eventName: normalized,
       url: window.location.href,
       userAgent: window.navigator.userAgent,
       scriptVersion: SCRIPT_VERSION,


### PR DESCRIPTION
# Summary

**TL;DR** Apiary is strict about payload shape but advertisers send what they send — strings where we expect numbers, objects where we expect ids, scalars where we expect arrays. This PR makes every optional field flow through a coercion helper so the wire format always conforms to Apiary, while preserving the underlying meaning of the data. Investigating the pixel-v2 DLQ ([BEE-20086](https://linear.app/beehiiv/issue/BEE-20086)) surfaced two new rejection causes we hadn't seen before — `content_ids` arriving as a single scalar (7,200 rows) and `order_id` arriving as a number (36 rows) — so we fix those at the source AND retrofit the same logic into a backfill script that re-submits the rejected events.

## The Full Story 🔍
<details>

### The Investigation

Pulled the last 30 days of failed pixel events from the `pixel_v2_dlq_json` ClickHouse table (10,000 rows). The breakdown by failed field was eye-opening:

| Count | Field | Root cause |
|-------|-------|------------|
| 7,200 | `content_ids` | sent as scalar string (Shopify variant id like `"43018101555409"`), expected array |
| 2,623 | `value_cents` | float drift (`3263.0000000000005`) — fixed in 2.2.3 for new traffic, but old DLQ rows still need cleanup |
| 76 | `subscriber_id` | truncated UUIDs, literal `"SUBSCRIBER"` template placeholder |
| 50 | `pixel_id` | literal `"PIXEL_ID"` (paste-the-template-without-editing), or Meta-style numeric ids |
| 36 | `order_id` | numeric Shopify order ids — backend wants string |
| 14 | `email_address_id` | truncated UUIDs |
| 1 | `ad_network_placement_id` | truncated UUID |

The two patterns we didn't already handle (`content_ids` as scalar and `order_id` as number) are textbook Shopify behavior — their datalayer hands us raw values, not pre-formatted ones. Fixing 7,236 of those at the source feels like a free win.

### The Invariant 🛡️

**Apiary's validator must never see a payload it would reject for shape reasons.** Every optional field is funneled through a coercion helper before it hits the wire — what comes out is either the canonical type Apiary expects, or `undefined`. Callers stay sloppy; the wire stays clean.

**Nightmare scenario (without this):** a Shopify storefront silently dumps months of conversion events into the DLQ because the datalayer sends `content_ids: 12345` instead of `["12345"]`. The advertiser sees zero attribution data, doesn't know why, and we eventually find out from a support ticket — by which time the data is unrecoverable in the live ad-spend window.

### The Fix 🔧

**Coercion (silent — meaning is preserved):**
- `toStringField()` for the optional string fields (`content_category`, `content_name`, `content_type`, `currency`, `search_string`, `status`) — trims, coerces primitives to string, returns `undefined` if empty
- `toStringArray()` for `content_ids` — wraps scalars, coerces members to strings, filters garbage
- `toIdString()` for `order_id` — coerces numbers to strings
- `getInt()` (existing) now applied to `num_items` too — was passing through unchanged

**Drop (truly invalid — no fix preserves meaning):**
- `[object Object]` anywhere in `content_ids` or `order_id` — that's a misconfigured datalayer, not data
- `NaN` / `Infinity` for numerics
- Objects/arrays passed where a primitive is expected
- Unknown event names in `track()` — pixel-v2 now uses the same `SUPPORTED_EVENTS` allowlist that pixel-shopify got in 2.2.3

**`console.warn` on every coercion that actually changed the input.** An advertiser sending `content_ids: 12345` now sees `[bhpx] content_ids: coerced 12345 → ["12345"]` in devtools and can fix their config — instead of silently shipping massaged payloads forever.

### The Backfill 🛠️

Pixel fixes plug the leak going forward. For the 9,950 already-rejected events sitting in the DLQ, there's a companion backfill script at `~/Projects/beehiiv/scratch/pixel-dlq/`:

1. `import.ts` — reads the CSV export, hashes each row for idempotent dedupe, extracts `pixel_id`/`event`/`url_host`/`error_field` columns so the ad-network team can `GROUP BY` for reporting without re-parsing JSON
2. `backfill.ts` — applies the same fix rules as the live pixel, POSTs cleaned payloads to `ingestion.apiary.beehiiv.net/api/v2/ingestion/pixel`, records `submitted`/`skipped`/`failed` with full audit trail per row (rate-limited 20 rps)

Dry-run shows 9,950 fixable, 50 unrecoverable (the literal `"PIXEL_ID"` placeholder rows — those represent advertisers who pasted the template without substituting their actual pixel id, and there's no way to attribute those after the fact).

### The Result ✨

- New pixel traffic from misbehaving Shopify datalayers will be accepted by Apiary instead of dumped to the DLQ
- The 9,950 historical events become recoverable via the backfill script
- Devtools warnings give advertisers a fast path to spotting bad data in their datalayers
- Bundle size: pixel-v2 grew 17 → 19 KB (gzip 5.48 → 6.05 KB) for the field-by-field sanitization. Net pixel-shopify also picked up the tighter coercions.

</details>

---
From Claudia with 💙
